### PR TITLE
Enable use of fv_nwp_nudge subroutine

### DIFF
--- a/FV3/atmos_cubed_sphere/driver/fvGFS/atmosphere.F90
+++ b/FV3/atmos_cubed_sphere/driver/fvGFS/atmosphere.F90
@@ -187,6 +187,7 @@ use fv_mp_mod,          only: switch_current_Atm
 use fv_sg_mod,          only: fv_subgrid_z
 use fv_update_phys_mod, only: fv_update_phys
 use fv_nwp_nudge_mod,   only: fv_nwp_nudge_init, fv_nwp_nudge_end, do_adiabatic_init
+use fv_io_mod,          only: fv_io_register_nudge_restart
 #ifdef MULTI_GASES
 use multi_gases_mod,  only: virq, virq_max, num_gas, ri, cpi
 #endif
@@ -438,6 +439,13 @@ contains
    id_fv_diag   = mpp_clock_id ('FV Diag',     flags = clock_flag_default, grain=CLOCK_SUBCOMPONENT )
 
                     call timing_off('ATMOS_INIT')
+
+   if ( Atm(mytile)%flagstruct%nudge ) then
+      call fv_nwp_nudge_init( Time, Atm(mytile)%atmos_axes, npz, zvir, Atm(mytile)%ak, Atm(mytile)%bk, Atm(mytile)%ts, &
+           Atm(mytile)%phis, Atm(mytile)%gridstruct, Atm(mytile)%ks, Atm(mytile)%npx, Atm(mytile)%neststruct, Atm(mytile)%bd)
+      call mpp_error(NOTE, 'NWP nudging is active')
+      call fv_io_register_nudge_restart ( Atm )
+   endif
 
 #ifdef CCPP
    ! Do CCPP fast physics initialization before call to adiabatic_init (since this calls fv_dynamics)
@@ -745,6 +753,7 @@ contains
    end if
 #endif
 
+   if ( Atm(mytile)%flagstruct%nudge ) call fv_nwp_nudge_end
    call nullify_domain ( )
    if (first_diag) then
       call timing_on('FV_DIAG')
@@ -1570,7 +1579,8 @@ contains
                          .true., Time_next, Atm(n)%flagstruct%nudge, Atm(n)%gridstruct,    &
                          Atm(n)%gridstruct%agrid(:,:,1), Atm(n)%gridstruct%agrid(:,:,2),   &
                          Atm(n)%npx, Atm(n)%npy, Atm(n)%npz, Atm(n)%flagstruct,            &
-                         Atm(n)%neststruct, Atm(n)%bd, Atm(n)%domain, Atm(n)%ptop)
+                         Atm(n)%neststruct, Atm(n)%bd, Atm(n)%domain, Atm(n)%ptop,         &
+                         Atm(n)%nudge_diag)
        call timing_off('FV_UPDATE_PHYS')
    call mpp_clock_end (id_dynam)
 

--- a/FV3/atmos_cubed_sphere/model/fv_arrays.F90
+++ b/FV3/atmos_cubed_sphere/model/fv_arrays.F90
@@ -111,6 +111,9 @@ module fv_arrays_mod
      real :: efx(max_step), efx_sum, efx_nest(max_step), efx_sum_nest, mtq(max_step), mtq_sum
      integer :: steps
 
+     integer :: id_t_dt_nudge, id_ps_dt_nudge, id_delp_dt_nudge
+     integer :: id_u_dt_nudge, id_v_dt_nudge, id_q_dt_nudge
+
   end type fv_diag_type
 
 
@@ -1119,6 +1122,17 @@ module fv_arrays_mod
 
   end type fv_nest_type
 
+  type nudge_diag_type
+
+      real, allocatable :: nudge_t_dt(:,:,:)
+      real, allocatable :: nudge_ps_dt(:,:)
+      real, allocatable :: nudge_delp_dt(:,:,:)
+      real, allocatable :: nudge_u_dt(:,:,:)
+      real, allocatable :: nudge_v_dt(:,:,:)
+      real, allocatable :: nudge_q_dt(:,:,:)
+
+   end type nudge_diag_type
+
 !>@brief 'allocate_fv_nest_BC_type' is an interface to subroutines
 !! that allocate the 'fv_nest_BC_type' structure that holds the nested-grid BCs.
 !>@details The subroutines can pass the array bounds explicitly or not.
@@ -1311,6 +1325,8 @@ module fv_arrays_mod
      real(kind=R_GRID), allocatable, dimension(:,:,:,:) :: grid_global
  
   integer :: atmos_axes(4)
+
+  type(nudge_diag_type) :: nudge_diag
 
   end type fv_atmos_type
 

--- a/FV3/atmos_cubed_sphere/tools/fv_diagnostics.F90
+++ b/FV3/atmos_cubed_sphere/tools/fv_diagnostics.F90
@@ -1016,6 +1016,61 @@ contains
 #ifndef GFS_PHYS
     if(idiag%id_theta_e >0 ) call qsmith_init
 #endif
+
+    idiag%id_t_dt_nudge = register_diag_field('dynamics', &
+          't_dt_nudge', axes(1:3), Time, &
+          'temperature tendency from nudging', &
+          'K/s', missing_value=missing_value)
+    if (idiag%id_t_dt_nudge > 0) then
+        allocate(Atm(n)%nudge_diag%nudge_t_dt(isc:iec,jsc:jec,npz))
+        Atm(n)%nudge_diag%nudge_t_dt(isc:iec,jsc:jec,npz) = 0.0
+    endif
+
+    idiag%id_ps_dt_nudge = register_diag_field('dynamics', &
+          'ps_dt_nudge', axes(1:2), Time, &
+          'surface pressure tendency from nudging', &
+          'Pa/s', missing_value=missing_value)
+    if (idiag%id_ps_dt_nudge > 0) then
+        allocate(Atm(n)%nudge_diag%nudge_ps_dt(isc:iec,jsc:jec))
+        Atm(n)%nudge_diag%nudge_ps_dt(isc:iec,jsc:jec) = 0.0
+    endif
+
+    idiag%id_delp_dt_nudge = register_diag_field('dynamics', &
+          'delp_dt_nudge', axes(1:3), Time, &
+          'pressure thickness tendency from nudging', &
+          'Pa/s', missing_value=missing_value)
+    if (idiag%id_delp_dt_nudge > 0) then
+        allocate(Atm(n)%nudge_diag%nudge_delp_dt(isc:iec,jsc:jec,npz))
+        Atm(n)%nudge_diag%nudge_delp_dt(isc:iec,jsc:jec,npz) = 0.0
+    endif
+
+    idiag%id_q_dt_nudge = register_diag_field('dynamics', &
+          'q_dt_nudge', axes(1:3), Time, &
+          'specific humidity tendency from nudging', &
+          'kg/kg/s', missing_value=missing_value)
+    if (idiag%id_q_dt_nudge > 0) then
+        allocate(Atm(n)%nudge_diag%nudge_q_dt(isc:iec,jsc:jec,npz))
+        Atm(n)%nudge_diag%nudge_q_dt(isc:iec,jsc:jec,npz) = 0.0
+    endif
+
+    idiag%id_u_dt_nudge = register_diag_field('dynamics', &
+          'u_dt_nudge', axes(1:3), Time, &
+          'zonal wind tendency from nudging', &
+          'm/s/s', missing_value=missing_value)
+    if (idiag%id_u_dt_nudge > 0) then
+        allocate(Atm(n)%nudge_diag%nudge_u_dt(isc:iec,jsc:jec,npz))
+        Atm(n)%nudge_diag%nudge_u_dt(isc:iec,jsc:jec,npz) = 0.0
+    endif
+
+    idiag%id_v_dt_nudge = register_diag_field('dynamics', &
+          'v_dt_nudge', axes(1:3), Time, &
+          'meridional wind tendency from nudging', &
+          'm/s/s', missing_value=missing_value)
+    if (idiag%id_v_dt_nudge > 0) then
+        allocate(Atm(n)%nudge_diag%nudge_v_dt(isc:iec,jsc:jec,npz))
+        Atm(n)%nudge_diag%nudge_v_dt(isc:iec,jsc:jec,npz) = 0.0
+    endif
+
  end subroutine fv_diag_init
 
 
@@ -3021,7 +3076,24 @@ contains
       endif
 
 #endif
-
+     if (idiag%id_t_dt_nudge > 0) then
+        used = send_data(idiag%id_t_dt_nudge, Atm(n)%nudge_diag%nudge_t_dt(isc:iec,jsc:jec,1:npz), Time)
+     endif
+     if (idiag%id_ps_dt_nudge > 0) then
+        used = send_data(idiag%id_ps_dt_nudge, Atm(n)%nudge_diag%nudge_ps_dt(isc:iec,jsc:jec), Time)
+     endif
+     if (idiag%id_delp_dt_nudge > 0) then
+        used = send_data(idiag%id_delp_dt_nudge, Atm(n)%nudge_diag%nudge_delp_dt(isc:iec,jsc:jec,1:npz), Time)
+     endif
+     if (idiag%id_q_dt_nudge > 0) then
+        used = send_data(idiag%id_q_dt_nudge, Atm(n)%nudge_diag%nudge_q_dt(isc:iec,jsc:jec,1:npz), Time)
+     endif
+     if (idiag%id_u_dt_nudge > 0) then
+        used = send_data(idiag%id_u_dt_nudge, Atm(n)%nudge_diag%nudge_u_dt(isc:iec,jsc:jec,1:npz), Time)
+     endif
+     if (idiag%id_v_dt_nudge > 0) then
+        used = send_data(idiag%id_v_dt_nudge, Atm(n)%nudge_diag%nudge_v_dt(isc:iec,jsc:jec,1:npz), Time)
+     endif
    ! enddo  ! end ntileMe do-loop
 
     deallocate ( a2 )

--- a/FV3/atmos_cubed_sphere/tools/fv_io.F90
+++ b/FV3/atmos_cubed_sphere/tools/fv_io.F90
@@ -596,7 +596,8 @@ contains
        if (.not. grids_on_this_pe(n)) cycle
 
        if ( (use_ncep_sst .or. Atm(n)%flagstruct%nudge) .and. .not. Atm(n)%gridstruct%nested ) then
-          call save_restart(Atm(n)%SST_restart, timestamp)
+          call mpp_error(NOTE, 'READING FROM SST_RESTART DISABLED')
+          !call save_restart(Atm(n)%SST_restart, timestamp)
        endif
  
        call save_restart(Atm(n)%Fv_restart, timestamp)

--- a/FV3/atmos_cubed_sphere/tools/fv_nudge.F90
+++ b/FV3/atmos_cubed_sphere/tools/fv_nudge.F90
@@ -754,9 +754,13 @@ module fv_nwp_nudge_mod
   call breed_srf_winds(Time, dt, npz, u_obs, v_obs, ak, bk, ps, phis, delp, ua, va, u_dt, v_dt, pt, q, nwat, zvir, gridstruct)
 
   if ( nudge_debug) then
-       call prt_maxmin('T increment=', t_dt,   is, ie, js, je, 0, npz, dt)
-       call prt_maxmin('U increment=', du_obs, is, ie, js, je, 0, npz, dt)
-       call prt_maxmin('V increment=', dv_obs, is, ie, js, je, 0, npz, dt)
+     if ( nudge_virt ) then
+        call prt_maxmin('T increment=', t_dt,   is, ie, js, je, 0, npz, dt)
+     endif
+     if ( nudge_winds ) then
+        call prt_maxmin('U increment=', du_obs, is, ie, js, je, 0, npz, dt)
+        call prt_maxmin('V increment=', dv_obs, is, ie, js, je, 0, npz, dt)
+     endif
   endif
 
   if ( nudge_winds ) then


### PR DESCRIPTION
This PR:

- allows use of `fv_nwp_nudge` subroutine in `fv_nudge.f90` module
- allows output of nudging tendencies
- allows nudging of specific humidity
- allows nudging of temperature or pressure without also nudging winds.

One notable change is that I have removed the variable `q_dt` as an output of the `fv_nwp_nudge` subroutine, since the variable it was output to was not actually present in the routine that calls `fv_nwp_nudge` (`q_dt` is an optional argument to `fv_update_phys` that is not actually used).

Some of these changes were previously implemented in the old fv3gfs repo [here](https://github.com/VulcanClimateModeling/fv3gfs/commit/d2169e3a33965d0653259c6bd2e6c25c8bf72d46) and [here](https://github.com/VulcanClimateModeling/fv3gfs/commit/53cf031a06505208176262e63eb9498e73349273).