### PR TITLE
Enable docker pull for fms, esmf, and serialbox prebuilt images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ jobs:
           command: |
             git submodule init
             git submodule update
-      - run: BUILD_FROM_INTERMEDIATE=y make build build_serialize
+      - run: DOCKER_BUILDKIT=1 BUILD_FROM_INTERMEDIATE=y make build build_serialize
       - restore_cache:
           keys:
             - v1.3-inputdata-{{ checksum "download_inputdata.sh" }}-{{ checksum "requirements.txt"}}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,8 @@ jobs:
           name: "gcloud auth"
           command: |
             echo $ENCODED_GCR_KEY | base64 -d > $GOOGLE_APPLICATION_CREDENTIALS
+            echo "export GCLOUD_SERVICE_KEY=\$(echo \$ENCODED_GCR_KEY | base64 --decode)" >> $BASH_ENV
+      - gcp-gcr/gcr-auth
       - run: 
           name: "Pull dependency images"
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,13 +7,14 @@ jobs:
       docker_layer_caching: true
     environment:
       FV3CONFIG_CACHE_DIR: /tmp/.fv3config
-      GOOGLE_APPLICATION_CREDENTIALS: ${HOME}/gcloud-service-key.json
+      GOOGLE_APPLICATION_CREDENTIALS: /tmp/key.json
     steps:
       - checkout
       - run:
           name: "gcloud auth"
           command: |
             echo $ENCODED_GCR_KEY | base64 -d > $GOOGLE_APPLICATION_CREDENTIALS
+            echo "export GCLOUD_SERVICE_KEY=\$(echo \$ENCODED_GCR_KEY | base64 --decode)" >> $BASH_ENV
       - gcp-gcr/gcr-auth
       - run: 
           name: "Pull dependency images"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ jobs:
           command: |
             git submodule init
             git submodule update
-      - run: DOCKER_BUILDKIT=1 BUILD_FROM_INTERMEDIATE=y make build build_serialize
+      - run: BUILD_FROM_INTERMEDIATE=y make build build_serialize
       - restore_cache:
           keys:
             - v1.3-inputdata-{{ checksum "download_inputdata.sh" }}-{{ checksum "requirements.txt"}}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,13 +14,10 @@ jobs:
           name: "gcloud auth"
           command: |
             echo $ENCODED_GCR_KEY | base64 -d > $GOOGLE_APPLICATION_CREDENTIALS
-            echo "export GCLOUD_SERVICE_KEY=\$(echo \$ENCODED_GCR_KEY | base64 --decode)" >> $BASH_ENV
-      - gcp-gcr/gcr-auth
       - run: 
           name: "Pull dependency images"
           command: |
             echo "$ENCODED_GCR_KEY" | base64 --decode | docker login --username _json_key --password-stdin https://gcr.io
-            docker pull us.gcr.io/vcm-ml/fms-build
             make pull_deps
       - run:
           name: "Pull Submodules"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
       docker_layer_caching: true
     environment:
       FV3CONFIG_CACHE_DIR: /tmp/.fv3config
-      GOOGLE_APPLICATION_CREDENTIALS: /tmp/key.json
+      GOOGLE_APPLICATION_CREDENTIALS: ${HOME}/gcloud-service-key.json
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,6 +20,7 @@ jobs:
           name: "Pull dependency images"
           command: |
             echo "$ENCODED_GCR_KEY" | base64 --decode | docker login --username _json_key --password-stdin https://gcr.io
+            docker pull us.gcr.io/vcm-ml/fms-build
             make pull_deps
       - run:
           name: "Pull Submodules"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,8 @@ jobs:
       - run:
           name: "gcloud auth"
           command: |
-            echo $ENCODED_GCR_KEY | base64 -d > $GOOGLE_APPLICATION_CREDENTIALS 
+            echo $ENCODED_GCR_KEY | base64 -d > $GOOGLE_APPLICATION_CREDENTIALS
+      - gcp-gcr/gcr-auth
       - run: 
           name: "Pull dependency images"
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,7 @@ jobs:
   build_default:
     machine:
       docker_layer_caching: true
+      image: ubuntu-1604:201903-01
     environment:
       FV3CONFIG_CACHE_DIR: /tmp/.fv3config
       GOOGLE_APPLICATION_CREDENTIALS: /tmp/key.json

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,12 +14,17 @@ jobs:
           name: "gcloud auth"
           command: |
             echo $ENCODED_GCR_KEY | base64 -d > $GOOGLE_APPLICATION_CREDENTIALS 
+      - run: 
+          name: "Pull dependency images"
+          command: |
+            echo "$ENCODED_GCR_KEY" | base64 --decode | docker login --username _json_key --password-stdin https://gcr.io
+            make pull_deps
       - run:
           name: "Pull Submodules"
           command: |
             git submodule init
             git submodule update
-      - run: make build build_serialize
+      - run: BUILD_FROM_INTERMEDIATE=y make build build_serialize
       - restore_cache:
           keys:
             - v1.3-inputdata-{{ checksum "download_inputdata.sh" }}-{{ checksum "requirements.txt"}}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ jobs:
           command: |
             git submodule init
             git submodule update
-      - run: BUILD_FROM_INTERMEDIATE=y make build build_serialize
+      - run: DOCKER_BUILDKIT=1 BUILD_FROM_INTERMEDIATE=y make build build_serialize
       - restore_cache:
           keys:
             - v1.3-inputdata-{{ checksum "download_inputdata.sh" }}-{{ checksum "requirements.txt"}}

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ build_compiled:
 		--target $(COMPILE_TARGET) .
 
 build_serialize:
-	BUILD_ARGS="$(BUILD_ARGS) --build-arg serialize=true" COMPILED_IMAGE=SERIALIZE_IMAGE $(MAKE) build_compiled
+	BUILD_ARGS="$(BUILD_ARGS) --build-arg serialize=true" COMPILED_IMAGE=$(SERIALIZE_IMAGE) $(MAKE) build_compiled
 
 build_deps:
 	docker build -f $(DOCKERFILE) -t $(FMS_IMAGE) --target fv3gfs-fms .

--- a/Makefile
+++ b/Makefile
@@ -58,9 +58,9 @@ push_deps:
 	docker push $(SERIALBOX_IMAGE)
 
 pull_deps:
-	docker push $(FMS_IMAGE)
-	docker push $(ESMF_IMAGE)
-	docker push $(SERIALBOX_IMAGE)
+	docker pull $(FMS_IMAGE)
+	docker pull $(ESMF_IMAGE)
+	docker pull $(SERIALBOX_IMAGE)
 
 build_debug: build_environment
 	COMPILED_TAG_NAME=debug COMPILE_OPTION="REPRO=\\\nDEBUG=Y" $(MAKE) build

--- a/Makefile
+++ b/Makefile
@@ -4,11 +4,17 @@ COMPILED_TAG_NAME ?= latest
 ENVIRONMENT_TAG_NAME ?= latest
 COMPILE_OPTION ?=
 COMPILE_TARGET ?= fv3gfs-compiled
+BUILD_ARGS ?=
+BUILD_FROM_INTERMEDIATE ?= n
 ENVIRONMENT_TARGET ?= fv3gfs-environment
 COMPILED_IMAGE ?= $(GCR_URL)/$(COMPILE_TARGET):$(COMPILED_TAG_NAME)
 SERIALIZE_IMAGE ?= $(GCR_URL)/$(COMPILE_TARGET):$(COMPILED_TAG_NAME)-serialize
 ENVIRONMENT_IMAGE=$(GCR_URL)/$(ENVIRONMENT_TARGET):$(ENVIRONMENT_TAG_NAME)
 IMAGE ?= $(ENVIRONMENT_IMAGE)
+
+FMS_IMAGE = $(GCR_URL)/fms-build
+ESMF_IMAGE = $(GCR_URL)/esmf-build
+SERIALBOX_IMAGE = $(GCR_URL)/serialbox-build
 
 MOUNTS?=-v $(shell pwd)/FV3:/FV3 \
 	-v $(shell pwd)/FV3/conf/configure.fv3.gnu_docker:/FV3/conf/configure.fv3
@@ -19,6 +25,11 @@ EXPERIMENT ?= new
 RUNDIR_CONTAINER=/rundir
 RUNDIR_HOST=$(shell pwd)/rundir
 
+
+ifeq ($(BUILD_FROM_INTERMEDIATE),y)
+	BUILD_ARGS += --build-arg FMS_IMAGE=$(FMS_IMAGE) --build-arg ESMF_IMAGE=$(ESMF_IMAGE) --build-arg SERIALBOX_IMAGE=$(SERIALBOX_IMAGE)
+endif
+
 build: build_compiled
 
 build_environment:
@@ -28,17 +39,28 @@ build_environment:
 build_compiled:
 	docker build \
 		--build-arg compile_option=$(COMPILE_OPTION) \
+		$(BUILD_ARGS) \
 		-f $(DOCKERFILE) \
 		-t $(COMPILED_IMAGE) \
 		--target $(COMPILE_TARGET) .
 
 build_serialize:
-	docker build \
-		--build-arg compile_option=$(COMPILE_OPTION) \
-		--build-arg serialize=true \
-		-f $(DOCKERFILE) \
-		-t $(SERIALIZE_IMAGE) \
-		--target $(COMPILE_TARGET) .
+	BUILD_ARGS="$(BUILD_ARGS) --build-arg serialize=true" COMPILED_IMAGE=SERIALIZE_IMAGE $(MAKE) build_compiled
+
+build_deps:
+	docker build -f $(DOCKERFILE) -t $(FMS_IMAGE) --target fv3gfs-fms .
+	docker build -f $(DOCKERFILE) -t $(ESMF_IMAGE) --target fv3gfs-esmf .
+	docker build -f $(DOCKERFILE) -t $(SERIALBOX_IMAGE) --target fv3gfs-environment-serialbox .
+
+push_deps:
+	docker push $(FMS_IMAGE)
+	docker push $(ESMF_IMAGE)
+	docker push $(SERIALBOX_IMAGE)
+
+pull_deps:
+	docker push $(FMS_IMAGE)
+	docker push $(ESMF_IMAGE)
+	docker push $(SERIALBOX_IMAGE)
 
 build_debug: build_environment
 	COMPILED_TAG_NAME=debug COMPILE_OPTION="REPRO=\\\nDEBUG=Y" $(MAKE) build

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,7 @@
 ARG serialize=false
+ARG FMS_IMAGE=fv3gfs-fms
+ARG ESMF_IMAGE=fv3gfs-esmf
+ARG SERIALBOX_IMAGE=fv3gfs-environment-serialbox
 
 FROM ubuntu:19.10 AS fv3gfs-environment
 
@@ -117,7 +120,7 @@ COPY FV3/atmos_cubed_sphere /FV3/atmos_cubed_sphere
 
 ## Convert FV3GFS sources for serialize image
 ##---------------------------------------------------------------------------------
-FROM fv3gfs-environment-serialbox AS fv3gfs-src-serialize-true
+FROM $SERIALBOX_IMAGE AS fv3gfs-src-serialize-true
 
 ENV FV3_BASE=/FV3/original
 COPY --from=fv3gfs-src-serialize-false /FV3 $FV3_BASE
@@ -139,21 +142,26 @@ RUN cd $FV3_BASE && make serialize_preprocess
 
 FROM fv3gfs-src-serialize-$serialize AS fv3gfs-sources
 
+FROM $FMS_IMAGE AS fms_image
+FROM $ESMF_IMAGE AS esmf_image
+FROM $SERIALBOX_IMAGE AS serialbox_image
+
 ## Build FV3 executable in its own image
 ##---------------------------------------------------------------------------------
 FROM fv3gfs-environment AS fv3gfs-build
 
-ENV SERIALBOX_DIR=/serialbox2
-ENV SERIALBOX_OUTDIR=/FV3
-ENV PPSER_PY=$(SERIALBOX_DIR)/python/pp_ser/pp_ser.py
-ENV FMS_DIR=/FMS
-ENV ESMF_DIR=/usr/local/esmf
-ENV ESMF_INC="-I/usr/local/esmf/include -I${ESMF_DIR}/mod/modO3/Linux.gfortran.64.mpiuni.default/"
-ENV LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${ESMF_DIR}/lib/libO3/Linux.gfortran.64.mpiuni.default/:${FMS_DIR}/libFMS/.libs/:${SERIALBOX_DIR}/lib
+ENV SERIALBOX_DIR=/serialbox2 \
+    SERIALBOX_OUTDIR=/FV3 \
+    FMS_DIR=/FMS \
+    ESMF_DIR=/usr/local/esmf
 
-COPY --from=fv3gfs-environment-serialbox /serialbox2/install $SERIALBOX_DIR
-COPY --from=fv3gfs-fms /FMS $FMS_DIR
-COPY --from=fv3gfs-esmf /usr/local/esmf ${ESMF_DIR}
+ENV ESMF_INC="-I/usr/local/esmf/include -I${ESMF_DIR}/mod/modO3/Linux.gfortran.64.mpiuni.default/" \
+    LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${ESMF_DIR}/lib/libO3/Linux.gfortran.64.mpiuni.default/:${FMS_DIR}/libFMS/.libs/:${SERIALBOX_DIR}/lib \
+    PPSER_PY=$(SERIALBOX_DIR)/python/pp_ser/pp_ser.py
+
+COPY --from=serialbox_image /serialbox2/install $SERIALBOX_DIR
+COPY --from=fms_image /FMS $FMS_DIR
+COPY --from=esmf_image /usr/local/esmf $ESMF_DIR
 
 COPY --from=fv3gfs-sources /FV3 /FV3
 COPY --from=fv3gfs-sources /stochastic_physics /stochastic_physics


### PR DESCRIPTION
Added make directives `build_deps` and `push_deps` which create docker images with built FMS, ESMF, and serialbox codes, `pull_deps` which pulls them, and an environment argument `BUILD_FROM_INTERMEDIATE` which when set to `y` will cause build directives to set build args using these intermediate images instead of the intermediate build stages in the files that produce them. CircleCI is configured to use `pull_deps` and `BUILD_FROM_INTERMEDIATE`.

This allows us to build and then push intermediate images which then never need to get re-built on CircleCI. Previously these images were being periodically re-built when the build cache was being flushed.

This does require manual management of the remote images. No versioning has been implemented for these images.