### PR TITLE
Make update_dwinds_phys subroutine public

### DIFF
--- a/FV3/atmos_cubed_sphere/model/fv_update_phys.F90
+++ b/FV3/atmos_cubed_sphere/model/fv_update_phys.F90
@@ -124,9 +124,7 @@ module fv_update_phys_mod
   implicit none
 
   public :: fv_update_phys, del2_phys
-#ifdef ROT3
   public :: update_dwinds_phys
-#endif
 
   real,parameter:: con_cp  = cp_air
 


### PR DESCRIPTION
Make `update_dwinds_phys` subroutine public regardless of preprocessor flags.