### PR TITLE
Add option to force physics SST to equal dynamical core surface temp

### DIFF
--- a/FV3/atmos_cubed_sphere/driver/fvGFS/atmosphere.F90
+++ b/FV3/atmos_cubed_sphere/driver/fvGFS/atmosphere.F90
@@ -1966,6 +1966,12 @@ contains
      endif
      IPD_Data(nb)%Statein%prsik(:,:) = 1.e25_kind_phys
 
+     do ix = 1, blen
+       i = Atm_block%index(nb)%ii(ix)
+       j = Atm_block%index(nb)%jj(ix)
+       IPD_Data(nb)%Statein%atm_ts(ix) = _DBL_(_RL_(Atm(mytile)%atm_ts(i,j)))
+     enddo
+
      do k = 1, npz
        !Indices for FV's vertical coordinate, for which 1 = top
        !here, k is the index for GFS's vertical coordinate, for which 1 =

--- a/FV3/atmos_cubed_sphere/driver/fvGFS/atmosphere.F90
+++ b/FV3/atmos_cubed_sphere/driver/fvGFS/atmosphere.F90
@@ -1969,7 +1969,7 @@ contains
      do ix = 1, blen
        i = Atm_block%index(nb)%ii(ix)
        j = Atm_block%index(nb)%jj(ix)
-       IPD_Data(nb)%Statein%atm_ts(ix) = _DBL_(_RL_(Atm(mytile)%atm_ts(i,j)))
+       IPD_Data(nb)%Statein%atm_ts(ix) = _DBL_(_RL_(Atm(mytile)%ts(i,j)))
      enddo
 
      do k = 1, npz

--- a/FV3/gfsphysics/GFS_layer/GFS_physics_driver.F90
+++ b/FV3/gfsphysics/GFS_layer/GFS_physics_driver.F90
@@ -2046,8 +2046,9 @@ module module_physics_driver
 
 !     if (lprnt) write(0,*) 'tisfc=',Sfcprop%tisfc(ipr),'tice=',tice(ipr),' kdt=',kdt
 
-! force SST to be equal to dynamical core surface temperature
-      if (Model%use_atm_ts_as_sst) then
+! force SST to be equal to dynamical core surface temperature, which will be the same as
+! analysis SST when nudging is active
+      if (Model%use_analysis_sst) then
         do i = 1, im
           if (islmsk(i) == 0 ) then
             Sfcprop%tsfc(i) = Statein%atm_ts(i)

--- a/FV3/gfsphysics/GFS_layer/GFS_physics_driver.F90
+++ b/FV3/gfsphysics/GFS_layer/GFS_physics_driver.F90
@@ -2046,6 +2046,17 @@ module module_physics_driver
 
 !     if (lprnt) write(0,*) 'tisfc=',Sfcprop%tisfc(ipr),'tice=',tice(ipr),' kdt=',kdt
 
+! force SST to be equal to dynamical core surface temperature
+      if (Model%use_atm_ts_as_sst) then
+        do i = 1, im
+          if (islmsk(i) == 0 ) then
+            Sfcprop%tsfc(i) = Statein%atm_ts(i)
+            Sfcprop%tsfco(i) = Statein%atm_ts(i)
+            tsfc3(i,3) = Statein%atm_ts(i)
+          endif
+        enddo
+      endif
+
       do i=1,im
         Diag%epi(i)     = ep1d(i)
         Diag%dlwsfci(i) = adjsfcdlw(i)

--- a/FV3/gfsphysics/GFS_layer/GFS_typedefs.F90
+++ b/FV3/gfsphysics/GFS_layer/GFS_typedefs.F90
@@ -748,8 +748,8 @@ module GFS_typedefs
     integer              :: iopt_stc  !snow/soil temperature time scheme (only layer 1)
 
     logical              :: use_ufo         !< flag for gcycle surface option
-    logical              :: use_atm_ts_as_sst ! whether to set physics SST to dynamical core ts
-
+    logical              :: use_analysis_sst ! whether to set physics SST to dynamical core ts, which is
+                                             ! equal to analysis SST when nudging is active
 !--- tuning parameters for physical parameterizations
     logical              :: ras             !< flag for ras convection scheme
     logical              :: flipv           !< flag for vertical direction flip (ras)
@@ -2807,7 +2807,8 @@ module GFS_typedefs
     integer              :: iopt_stc       =  1  !snow/soil temperature time scheme (only layer 1)
 
     logical              :: use_ufo        = .false.         !< flag for gcycle surface option
-    logical              :: use_atm_ts_as_sst = .false.      ! whether to set physics SST equal to Atm(n)%ts
+    logical              :: use_analysis_sst = .false. ! whether to set physics SST to dynamical core ts
+                                                       ! which is equal to analysis SST when nudging is active
 
 !--- tuning parameters for physical parameterizations
     logical              :: ras            = .false.                  !< flag for ras convection scheme
@@ -3070,7 +3071,7 @@ module GFS_typedefs
 #else
                                lsm, lsoil, nmtvr, ivegsrc, use_ufo,                         &
 #endif
-                               use_atm_ts_as_sst,                                           &
+                               use_analysis_sst,                                           &
                           !    Noah MP options
                                iopt_dveg,iopt_crs,iopt_btr,iopt_run,iopt_sfc, iopt_frz,     &
                                iopt_inf, iopt_rad,iopt_alb,iopt_snf,iopt_tbot,iopt_stc,     &
@@ -3380,7 +3381,7 @@ module GFS_typedefs
     Model%isot             = isot
     Model%use_ufo          = use_ufo
 
-    Model%use_atm_ts_as_sst = use_atm_ts_as_sst
+    Model%use_analysis_sst = use_analysis_sst
 
 ! Noah MP options from namelist
 !
@@ -3897,7 +3898,7 @@ module GFS_typedefs
       endif
 
       print *,' nst_anl=',Model%nst_anl,' use_ufo=',Model%use_ufo,' frac_grid=',Model%frac_grid
-      print *,' use_atm_ts_as_sst=',Model%use_atm_ts_as_sst
+      print *,' use_analysis_sst=',Model%use_analysis_sst
       print *,' min_lakeice=',Model%min_lakeice,' min_seaice=',Model%min_seaice
       if (Model%nstf_name(1) > 0 ) then
         print *,' NSSTM is active '
@@ -4403,7 +4404,7 @@ module GFS_typedefs
      endif
 
       print *, ' use_ufo           : ', Model%use_ufo
-      print *, ' use_atm_ts_as_sst : ', Model%use_atm_ts_as_sst
+      print *, ' use_analysis_sst : ', Model%use_analysis_sst
       print *, ' '
       print *, 'tuning parameters for physical parameterizations'
       print *, ' ras               : ', Model%ras

--- a/FV3/gfsphysics/GFS_layer/GFS_typedefs.F90
+++ b/FV3/gfsphysics/GFS_layer/GFS_typedefs.F90
@@ -184,7 +184,7 @@ module GFS_typedefs
     real (kind=kind_phys), pointer :: smc (:,:)   => null()  !< soil moisture content
     real (kind=kind_phys), pointer :: stc (:,:)   => null()  !< soil temperature content
     real (kind=kind_phys), pointer :: slc (:,:)   => null()  !< soil liquid water content
-    real (kind=kind_phys), pointer :: atm_ts (:,:) => null() !< surface temperature from dynamical core
+    real (kind=kind_phys), pointer :: atm_ts (:)  => null() !< surface temperature from dynamical core
  
     contains
       procedure :: create  => statein_create  !<   allocate array data


### PR DESCRIPTION
This option is needed in order to ensure that nudged runs are using the surface temperature from the GFS analysis.