### PR TITLE
Some initial infrastructure for online coarse-graining

### DIFF
--- a/FV3/atmos_cubed_sphere/driver/fvGFS/atmosphere.F90
+++ b/FV3/atmos_cubed_sphere/driver/fvGFS/atmosphere.F90
@@ -195,7 +195,7 @@ use fv_regional_mod,    only: start_regional_restart, read_new_bc_data, &
                               a_step, p_step, current_time_in_seconds
 
 use mpp_domains_mod,    only:  mpp_get_data_domain, mpp_get_compute_domain
-use online_coarse_graining_mod, only: online_coarse_graining_init
+use coarse_graining_mod, only: coarse_graining_init
 use coarse_grained_diagnostics_mod, only: fv_coarse_diag_init, fv_coarse_diag
 !$ser verbatim use k_checkpoint, only: set_nz
 
@@ -337,7 +337,8 @@ contains
       if (grids_on_this_pe(n)) mytile = n
    enddo
 
-   call online_coarse_graining_init(Atm(mytile))
+   call coarse_graining_init(Atm(mytile)%flagstruct%npx, Atm(mytile)%npz, &
+        Atm(mytile)%layout, Atm(mytile)%bd, Atm(mytile)%coarse_graining)
 
    Atm(mytile)%Time_init = Time_init
 
@@ -430,8 +431,9 @@ contains
        !I've had trouble getting this to work with multiple grids at a time; worth revisiting?
    call fv_diag_init(Atm(mytile:mytile), Atm(mytile)%atmos_axes, Time, npx, npy, npz, Atm(mytile)%flagstruct%p_ref)
 
-   if (Atm(mytile)%coarse_graining_attrs%do_coarse_graining) then
-      call fv_coarse_diag_init(Atm(mytile:mytile), Atm(mytile)%coarse_graining_attrs%diagnostic_axes, Time)
+   if (Atm(mytile)%coarse_graining%do_coarse_graining) then
+      call fv_coarse_diag_init(Atm(mytile)%bd, Time, Atm(mytile)%atmos_axes(3), &
+           Atm(mytile)%atmos_axes(4), Atm(mytile)%coarse_graining)
    endif
 !---------- reference profile -----------
     ps1 = 101325.
@@ -786,7 +788,7 @@ contains
       call timing_on('FV_DIAG')
       call fv_diag(Atm(mytile:mytile), zvir, fv_time, Atm(mytile)%flagstruct%print_freq)
       call fv_nggps_diag(Atm(mytile:mytile), zvir, fv_time)
-      if (Atm(mytile)%coarse_graining_attrs%do_coarse_graining) then
+      if (Atm(mytile)%coarse_graining%do_coarse_graining) then
          call fv_coarse_diag(Atm(mytile:mytile), fv_time)
       endif
       first_diag = .false.
@@ -1637,7 +1639,7 @@ contains
      call nullify_domain()
      call timing_on('FV_DIAG')
      call fv_diag(Atm(mytile:mytile), zvir, fv_time, Atm(mytile)%flagstruct%print_freq)
-     if (Atm(mytile)%coarse_graining_attrs%do_coarse_graining) then
+     if (Atm(mytile)%coarse_graining%do_coarse_graining) then
         call fv_coarse_diag(Atm(mytile:mytile), fv_time)
      endif
      first_diag = .false.

--- a/FV3/atmos_cubed_sphere/driver/fvGFS/atmosphere.F90
+++ b/FV3/atmos_cubed_sphere/driver/fvGFS/atmosphere.F90
@@ -429,8 +429,10 @@ contains
 !----- initialize atmos_axes and fv_dynamics diagnostics
        !I've had trouble getting this to work with multiple grids at a time; worth revisiting?
    call fv_diag_init(Atm(mytile:mytile), Atm(mytile)%atmos_axes, Time, npx, npy, npz, Atm(mytile)%flagstruct%p_ref)
-   call fv_coarse_diag_init(Atm(mytile:mytile), Atm(mytile)%coarse_atmos_axes, Time)
 
+   if (Atm(mytile)%coarse_graining_attributes%write_coarse_grained_diagnostics) then
+      call fv_coarse_diag_init(Atm(mytile:mytile), Atm(mytile)%coarse_graining_attributes%coarse_diagnostic_axes, Time)
+   endif
 !---------- reference profile -----------
     ps1 = 101325.
     ps2 =  81060.
@@ -784,7 +786,9 @@ contains
       call timing_on('FV_DIAG')
       call fv_diag(Atm(mytile:mytile), zvir, fv_time, Atm(mytile)%flagstruct%print_freq)
       call fv_nggps_diag(Atm(mytile:mytile), zvir, fv_time)
-      call fv_coarse_diag(Atm(mytile:mytile), fv_time)
+      if (Atm(mytile)%coarse_graining_attributes%write_coarse_grained_diagnostics) then
+         call fv_coarse_diag(Atm(mytile:mytile), fv_time)
+      endif
       first_diag = .false.
       call timing_off('FV_DIAG')
    endif
@@ -1633,7 +1637,9 @@ contains
      call nullify_domain()
      call timing_on('FV_DIAG')
      call fv_diag(Atm(mytile:mytile), zvir, fv_time, Atm(mytile)%flagstruct%print_freq)
-     call fv_coarse_diag(Atm(mytile:mytile), fv_time)
+     if (Atm(mytile)%coarse_graining_attributes%write_coarse_grained_diagnostics) then
+        call fv_coarse_diag(Atm(mytile:mytile), fv_time)
+     endif
      first_diag = .false.
      call timing_off('FV_DIAG')
 

--- a/FV3/atmos_cubed_sphere/driver/fvGFS/atmosphere.F90
+++ b/FV3/atmos_cubed_sphere/driver/fvGFS/atmosphere.F90
@@ -430,8 +430,8 @@ contains
        !I've had trouble getting this to work with multiple grids at a time; worth revisiting?
    call fv_diag_init(Atm(mytile:mytile), Atm(mytile)%atmos_axes, Time, npx, npy, npz, Atm(mytile)%flagstruct%p_ref)
 
-   if (Atm(mytile)%coarse_graining_attributes%enable_coarse_graining) then
-      call fv_coarse_diag_init(Atm(mytile:mytile), Atm(mytile)%coarse_graining_attributes%coarse_diagnostic_axes, Time)
+   if (Atm(mytile)%coarse_graining_attrs%do_coarse_graining) then
+      call fv_coarse_diag_init(Atm(mytile:mytile), Atm(mytile)%coarse_graining_attrs%diagnostic_axes, Time)
    endif
 !---------- reference profile -----------
     ps1 = 101325.
@@ -786,7 +786,7 @@ contains
       call timing_on('FV_DIAG')
       call fv_diag(Atm(mytile:mytile), zvir, fv_time, Atm(mytile)%flagstruct%print_freq)
       call fv_nggps_diag(Atm(mytile:mytile), zvir, fv_time)
-      if (Atm(mytile)%coarse_graining_attributes%enable_coarse_graining) then
+      if (Atm(mytile)%coarse_graining_attrs%do_coarse_graining) then
          call fv_coarse_diag(Atm(mytile:mytile), fv_time)
       endif
       first_diag = .false.
@@ -1637,7 +1637,7 @@ contains
      call nullify_domain()
      call timing_on('FV_DIAG')
      call fv_diag(Atm(mytile:mytile), zvir, fv_time, Atm(mytile)%flagstruct%print_freq)
-     if (Atm(mytile)%coarse_graining_attributes%enable_coarse_graining) then
+     if (Atm(mytile)%coarse_graining_attrs%do_coarse_graining) then
         call fv_coarse_diag(Atm(mytile:mytile), fv_time)
      endif
      first_diag = .false.

--- a/FV3/atmos_cubed_sphere/driver/fvGFS/atmosphere.F90
+++ b/FV3/atmos_cubed_sphere/driver/fvGFS/atmosphere.F90
@@ -337,8 +337,10 @@ contains
       if (grids_on_this_pe(n)) mytile = n
    enddo
 
-   call coarse_graining_init(Atm(mytile)%flagstruct%npx, Atm(mytile)%npz, &
-        Atm(mytile)%layout, Atm(mytile)%bd, Atm(mytile)%coarse_graining)
+   if (Atm(mytile)%flagstruct%do_coarse_graining) then
+      call coarse_graining_init(Atm(mytile)%flagstruct%npx, Atm(mytile)%npz, &
+           Atm(mytile)%layout, Atm(mytile)%bd, Atm(mytile)%coarse_graining)
+   endif
 
    Atm(mytile)%Time_init = Time_init
 

--- a/FV3/atmos_cubed_sphere/driver/fvGFS/atmosphere.F90
+++ b/FV3/atmos_cubed_sphere/driver/fvGFS/atmosphere.F90
@@ -430,7 +430,7 @@ contains
        !I've had trouble getting this to work with multiple grids at a time; worth revisiting?
    call fv_diag_init(Atm(mytile:mytile), Atm(mytile)%atmos_axes, Time, npx, npy, npz, Atm(mytile)%flagstruct%p_ref)
 
-   if (Atm(mytile)%coarse_graining_attributes%write_coarse_grained_diagnostics) then
+   if (Atm(mytile)%coarse_graining_attributes%enable_coarse_graining) then
       call fv_coarse_diag_init(Atm(mytile:mytile), Atm(mytile)%coarse_graining_attributes%coarse_diagnostic_axes, Time)
    endif
 !---------- reference profile -----------
@@ -786,7 +786,7 @@ contains
       call timing_on('FV_DIAG')
       call fv_diag(Atm(mytile:mytile), zvir, fv_time, Atm(mytile)%flagstruct%print_freq)
       call fv_nggps_diag(Atm(mytile:mytile), zvir, fv_time)
-      if (Atm(mytile)%coarse_graining_attributes%write_coarse_grained_diagnostics) then
+      if (Atm(mytile)%coarse_graining_attributes%enable_coarse_graining) then
          call fv_coarse_diag(Atm(mytile:mytile), fv_time)
       endif
       first_diag = .false.
@@ -1637,7 +1637,7 @@ contains
      call nullify_domain()
      call timing_on('FV_DIAG')
      call fv_diag(Atm(mytile:mytile), zvir, fv_time, Atm(mytile)%flagstruct%print_freq)
-     if (Atm(mytile)%coarse_graining_attributes%write_coarse_grained_diagnostics) then
+     if (Atm(mytile)%coarse_graining_attributes%enable_coarse_graining) then
         call fv_coarse_diag(Atm(mytile:mytile), fv_time)
      endif
      first_diag = .false.

--- a/FV3/atmos_cubed_sphere/makefile
+++ b/FV3/atmos_cubed_sphere/makefile
@@ -68,7 +68,7 @@ SRCS_F90 = \
 		   ./tools/fv_surf_map.F90                        \
 		   ./tools/fv_timing.F90                          \
 		   ./tools/init_hydro.F90                         \
-                   ./tools/online_coarse_graining.F90             \
+                   ./tools/coarse_graining.F90             \
 		   ./tools/sim_nc_mod.F90                         \
 		   ./tools/sorted_index.F90                       \
 		   ./tools/test_cases.F90                         \

--- a/FV3/atmos_cubed_sphere/makefile
+++ b/FV3/atmos_cubed_sphere/makefile
@@ -55,6 +55,7 @@ SRCS_F90 = \
 		   ./model/nh_utils.F90                           \
 		   ./tools/external_ic.F90                        \
 		   ./tools/external_sst.F90                       \
+                   ./tools/coarse_grained_diagnostics.F90         \
 		   ./tools/fv_diagnostics.F90                     \
 		   ./tools/fv_eta.F90                             \
 		   ./tools/fv_grid_tools.F90                      \
@@ -67,6 +68,7 @@ SRCS_F90 = \
 		   ./tools/fv_surf_map.F90                        \
 		   ./tools/fv_timing.F90                          \
 		   ./tools/init_hydro.F90                         \
+                   ./tools/online_coarse_graining.F90             \
 		   ./tools/sim_nc_mod.F90                         \
 		   ./tools/sorted_index.F90                       \
 		   ./tools/test_cases.F90                         \

--- a/FV3/atmos_cubed_sphere/model/fv_arrays.F90
+++ b/FV3/atmos_cubed_sphere/model/fv_arrays.F90
@@ -116,6 +116,11 @@ module fv_arrays_mod
 
   end type fv_diag_type
 
+  type fv_coarse_diag_type
+
+     integer :: id_omega_coarse
+
+  end type fv_coarse_diag_type
 
 !>@brief The type 'fv_grid_type' is made up of grid-dependent information from fv_grid_tools and fv_grid_utils.
 !>@details It should not contain any user options (that goes in a different structure) nor data which
@@ -1158,6 +1163,12 @@ module fv_arrays_mod
 
   end type fv_grid_bounds_type
 
+  type fv_coarse_grid_bounds_type
+
+     integer :: is_coarse, ie_coarse, js_coarse, je_coarse
+
+  end type fv_coarse_grid_bounds_type
+
   type fv_regional_bc_bounds_type
 
      integer :: is_north ,ie_north ,js_north ,je_north &
@@ -1274,9 +1285,15 @@ module fv_arrays_mod
 
     type(fv_grid_bounds_type) :: bd
 
+    type(fv_coarse_grid_bounds_type) :: coarse_bd
+
     type(fv_regional_bc_bounds_type) :: regional_bc_bounds
 
     type(domain2D) :: domain
+
+    type(domain2D) :: coarse_domain
+
+    integer :: target_coarse_resolution
 #if defined(SPMD)
 
     type(domain2D) :: domain_for_coupler !< domain used in coupled model with halo = 1.
@@ -1312,6 +1329,7 @@ module fv_arrays_mod
 !!!!!!!!!!!!!!!!
 
      type(fv_diag_type) :: idiag
+     type(fv_coarse_diag_type) :: idiag_coarse
 
 !!!!!!!!!!!!!!
 ! From fv_io !
@@ -1325,6 +1343,7 @@ module fv_arrays_mod
      real(kind=R_GRID), allocatable, dimension(:,:,:,:) :: grid_global
  
   integer :: atmos_axes(4)
+  integer :: coarse_atmos_axes(4)
 
   type(nudge_diag_type) :: nudge_diag
 

--- a/FV3/atmos_cubed_sphere/model/fv_arrays.F90
+++ b/FV3/atmos_cubed_sphere/model/fv_arrays.F90
@@ -1182,7 +1182,7 @@ module fv_arrays_mod
      integer :: id_yt_coarse  ! diagnostic y-axis id for data on y-centers
      integer :: id_pfull  ! diagnostic vertical axis id for data on z-centers
      integer :: id_phalf  ! diagnostic vertical axis id for data on z-edges
-     character(len=64) :: strategy
+     character(len=64) :: strategy  ! Current valid values are: 'model_level'
      logical :: do_coarse_graining
      type(fv_coarse_diag_type) :: idiag  ! container for coarse diagnostic ids
 

--- a/FV3/atmos_cubed_sphere/model/fv_arrays.F90
+++ b/FV3/atmos_cubed_sphere/model/fv_arrays.F90
@@ -119,7 +119,10 @@ module fv_arrays_mod
   type fv_coarse_diag_type
 
      integer :: id_omega_coarse
-
+     integer :: id_grid_lont_coarse, id_grid_lon_coarse, id_grid_latt_coarse, id_grid_lat_coarse
+     integer :: id_area_coarse, id_dx_coarse, id_dy_coarse
+     integer :: n_3d_diagnostics = 1
+     
   end type fv_coarse_diag_type
 
 !>@brief The type 'fv_grid_type' is made up of grid-dependent information from fv_grid_tools and fv_grid_utils.

--- a/FV3/atmos_cubed_sphere/model/fv_arrays.F90
+++ b/FV3/atmos_cubed_sphere/model/fv_arrays.F90
@@ -1172,13 +1172,13 @@ module fv_arrays_mod
 
   type fv_coarse_graining_type
 
-     type(fv_coarse_grid_bounds_type) :: coarse_bd
-     type(domain2d) :: coarse_domain
-     integer :: coarsening_factor
-     integer :: target_coarse_resolution
-     integer :: coarse_diagnostic_axes(4)
-     character(len=64) :: coarse_graining_strategy
-     logical :: enable_coarse_graining
+     type(fv_coarse_grid_bounds_type) :: bd
+     type(domain2d) :: domain
+     integer :: factor
+     integer :: target_resolution
+     integer :: diagnostic_axes(4)
+     character(len=64) :: strategy
+     logical :: do_coarse_graining
 
   end type fv_coarse_graining_type
   
@@ -1353,7 +1353,7 @@ module fv_arrays_mod
 
   type(nudge_diag_type) :: nudge_diag
 
-  type(fv_coarse_graining_type) :: coarse_graining_attributes
+  type(fv_coarse_graining_type) :: coarse_graining_attrs
   
   end type fv_atmos_type
 

--- a/FV3/atmos_cubed_sphere/model/fv_arrays.F90
+++ b/FV3/atmos_cubed_sphere/model/fv_arrays.F90
@@ -1169,6 +1169,19 @@ module fv_arrays_mod
 
   end type fv_coarse_grid_bounds_type
 
+  type fv_coarse_graining_type
+
+     type(fv_coarse_grid_bounds_type) :: coarse_bd
+     type(domain2d) :: coarse_domain
+     integer :: coarsening_factor
+     integer :: target_coarse_resolution
+     integer :: coarse_diagnostic_axes(4)
+     character(len=64) :: coarse_graining_strategy
+     logical :: write_coarse_grained_restart_files
+     logical :: write_coarse_grained_diagnostics
+
+  end type fv_coarse_graining_type
+  
   type fv_regional_bc_bounds_type
 
      integer :: is_north ,ie_north ,js_north ,je_north &
@@ -1285,15 +1298,10 @@ module fv_arrays_mod
 
     type(fv_grid_bounds_type) :: bd
 
-    type(fv_coarse_grid_bounds_type) :: coarse_bd
-
     type(fv_regional_bc_bounds_type) :: regional_bc_bounds
 
     type(domain2D) :: domain
 
-    type(domain2D) :: coarse_domain
-
-    integer :: target_coarse_resolution
 #if defined(SPMD)
 
     type(domain2D) :: domain_for_coupler !< domain used in coupled model with halo = 1.
@@ -1343,10 +1351,11 @@ module fv_arrays_mod
      real(kind=R_GRID), allocatable, dimension(:,:,:,:) :: grid_global
  
   integer :: atmos_axes(4)
-  integer :: coarse_atmos_axes(4)
 
   type(nudge_diag_type) :: nudge_diag
 
+  type(fv_coarse_graining_type) :: coarse_graining_attributes
+  
   end type fv_atmos_type
 
 contains

--- a/FV3/atmos_cubed_sphere/model/fv_arrays.F90
+++ b/FV3/atmos_cubed_sphere/model/fv_arrays.F90
@@ -1178,8 +1178,7 @@ module fv_arrays_mod
      integer :: target_coarse_resolution
      integer :: coarse_diagnostic_axes(4)
      character(len=64) :: coarse_graining_strategy
-     logical :: write_coarse_grained_restart_files
-     logical :: write_coarse_grained_diagnostics
+     logical :: enable_coarse_graining
 
   end type fv_coarse_graining_type
   

--- a/FV3/atmos_cubed_sphere/model/fv_arrays.F90
+++ b/FV3/atmos_cubed_sphere/model/fv_arrays.F90
@@ -1301,7 +1301,6 @@ module fv_arrays_mod
     type(fv_regional_bc_bounds_type) :: regional_bc_bounds
 
     type(domain2D) :: domain
-
 #if defined(SPMD)
 
     type(domain2D) :: domain_for_coupler !< domain used in coupled model with halo = 1.

--- a/FV3/atmos_cubed_sphere/model/fv_arrays.F90
+++ b/FV3/atmos_cubed_sphere/model/fv_arrays.F90
@@ -1021,10 +1021,10 @@ module fv_arrays_mod
    !f1p
    logical  :: adj_mass_vmr = .false. !TER: This is to reproduce answers for verona patch.  This default can be changed
                                      !     to .true. in the next city release if desired
-  
+
+   logical :: do_coarse_graining = .false.  ! Whether to enable online coarse-graining of restart files and diagnostics
   !integer, pointer :: test_case
   !real,    pointer :: alpha
-
   end type fv_flags_type
 
   type fv_nest_BC_type_3D
@@ -1183,7 +1183,7 @@ module fv_arrays_mod
      integer :: id_pfull  ! diagnostic vertical axis id for data on z-centers
      integer :: id_phalf  ! diagnostic vertical axis id for data on z-edges
      character(len=64) :: strategy  ! Current valid values are: 'model_level'
-     logical :: do_coarse_graining
+     logical :: do_coarse_graining = .false.
      type(fv_coarse_diag_type) :: idiag  ! container for coarse diagnostic ids
 
   end type fv_coarse_graining_type
@@ -1359,7 +1359,7 @@ module fv_arrays_mod
   type(nudge_diag_type) :: nudge_diag
 
   type(fv_coarse_graining_type) :: coarse_graining
-  
+
   end type fv_atmos_type
 
 contains

--- a/FV3/atmos_cubed_sphere/model/fv_arrays.F90
+++ b/FV3/atmos_cubed_sphere/model/fv_arrays.F90
@@ -119,10 +119,7 @@ module fv_arrays_mod
   type fv_coarse_diag_type
 
      integer :: id_omega_coarse
-     integer :: id_grid_lont_coarse, id_grid_lon_coarse, id_grid_latt_coarse, id_grid_lat_coarse
-     integer :: id_area_coarse, id_dx_coarse, id_dy_coarse
      integer :: n_3d_diagnostics = 1
-     integer :: n_2d_cell_centered_static_diagnostics = 3
      
   end type fv_coarse_diag_type
 

--- a/FV3/atmos_cubed_sphere/model/fv_arrays.F90
+++ b/FV3/atmos_cubed_sphere/model/fv_arrays.F90
@@ -122,6 +122,7 @@ module fv_arrays_mod
      integer :: id_grid_lont_coarse, id_grid_lon_coarse, id_grid_latt_coarse, id_grid_lat_coarse
      integer :: id_area_coarse, id_dx_coarse, id_dy_coarse
      integer :: n_3d_diagnostics = 1
+     integer :: n_2d_cell_centered_static_diagnostics = 3
      
   end type fv_coarse_diag_type
 

--- a/FV3/atmos_cubed_sphere/model/fv_arrays.F90
+++ b/FV3/atmos_cubed_sphere/model/fv_arrays.F90
@@ -1175,10 +1175,16 @@ module fv_arrays_mod
      type(fv_coarse_grid_bounds_type) :: bd
      type(domain2d) :: domain
      integer :: factor
-     integer :: target_resolution
-     integer :: diagnostic_axes(4)
+     integer :: nx_coarse
+     integer :: id_x_coarse  ! diagnostic x-axis id for data on x-edges
+     integer :: id_y_coarse  ! diagnostic y-axis id for data on y-edges
+     integer :: id_xt_coarse  ! diagnostic x-axis id for data on x-centers
+     integer :: id_yt_coarse  ! diagnostic y-axis id for data on y-centers
+     integer :: id_pfull  ! diagnostic vertical axis id for data on z-centers
+     integer :: id_phalf  ! diagnostic vertical axis id for data on z-edges
      character(len=64) :: strategy
      logical :: do_coarse_graining
+     type(fv_coarse_diag_type) :: idiag  ! container for coarse diagnostic ids
 
   end type fv_coarse_graining_type
   
@@ -1336,7 +1342,6 @@ module fv_arrays_mod
 !!!!!!!!!!!!!!!!
 
      type(fv_diag_type) :: idiag
-     type(fv_coarse_diag_type) :: idiag_coarse
 
 !!!!!!!!!!!!!!
 ! From fv_io !
@@ -1353,7 +1358,7 @@ module fv_arrays_mod
 
   type(nudge_diag_type) :: nudge_diag
 
-  type(fv_coarse_graining_type) :: coarse_graining_attrs
+  type(fv_coarse_graining_type) :: coarse_graining
   
   end type fv_atmos_type
 

--- a/FV3/atmos_cubed_sphere/model/fv_control.F90
+++ b/FV3/atmos_cubed_sphere/model/fv_control.F90
@@ -335,7 +335,6 @@ module fv_control_mod
   real, pointer :: s_weight, update_blend
 
   integer, pointer :: layout(:), io_layout(:)
-
    integer :: ntilesMe                ! Number of tiles on this process =1 for now
 
 #ifdef OVERLOAD_R4

--- a/FV3/atmos_cubed_sphere/model/fv_control.F90
+++ b/FV3/atmos_cubed_sphere/model/fv_control.F90
@@ -335,6 +335,7 @@ module fv_control_mod
   real, pointer :: s_weight, update_blend
 
   integer, pointer :: layout(:), io_layout(:)
+
    integer :: ntilesMe                ! Number of tiles on this process =1 for now
 
 #ifdef OVERLOAD_R4

--- a/FV3/atmos_cubed_sphere/model/fv_control.F90
+++ b/FV3/atmos_cubed_sphere/model/fv_control.F90
@@ -335,6 +335,7 @@ module fv_control_mod
   real, pointer :: s_weight, update_blend
 
   integer, pointer :: layout(:), io_layout(:)
+  logical, pointer :: do_coarse_graining
 
    integer :: ntilesMe                ! Number of tiles on this process =1 for now
 
@@ -669,7 +670,7 @@ module fv_control_mod
                          nested, twowaynest, parent_grid_num, parent_tile, nudge_qv, &
                          refinement, nestbctype, nestupdate, nsponge, s_weight, &
                          ioffset, joffset, check_negative, nudge_ic, halo_update_type, gfs_phil, agrid_vel_rst,     &
-                         do_uni_zfull, adj_mass_vmr, fac_n_spl, fhouri, regional, bc_update_interval
+                         do_uni_zfull, adj_mass_vmr, fac_n_spl, fhouri, regional, bc_update_interval, do_coarse_graining
 
    namelist /test_case_nml/test_case, bubble_do, alpha, nsolitons, soliton_Umax, soliton_size
 #ifdef MULTI_GASES
@@ -1340,6 +1341,7 @@ module fv_control_mod
 
      layout                        => Atm%layout
      io_layout                     => Atm%io_layout
+     do_coarse_graining            => Atm%flagstruct%do_coarse_graining
   end subroutine setup_pointers
 
        

--- a/FV3/atmos_cubed_sphere/tools/coarse_grained_diagnostics.F90
+++ b/FV3/atmos_cubed_sphere/tools/coarse_grained_diagnostics.F90
@@ -29,8 +29,8 @@ contains
     call get_fine_array_bounds(Atm(tile_count), is, ie, js, je)
     call get_coarse_array_bounds(Atm(tile_count), is_coarse, ie_coarse, js_coarse, je_coarse)    
     call initialize_coarse_diagnostic_axes( &
-         Atm(tile_count)%coarse_graining_attributes%coarse_domain, &
-         Atm(tile_count)%coarse_graining_attributes%target_coarse_resolution, &         
+         Atm(tile_count)%coarse_graining_attrs%domain, &
+         Atm(tile_count)%coarse_graining_attrs%target_resolution, &         
          id_x_coarse, id_y_coarse, id_xt_coarse, id_yt_coarse)
 
     id_pfull = Atm(tile_count)%atmos_axes(3)
@@ -105,7 +105,7 @@ contains
  
     character(len=256) :: error_message
 
-    if (trim(Atm(tile_count)%coarse_graining_attributes%coarse_graining_strategy) .eq. MODEL_LEVEL) then
+    if (trim(Atm(tile_count)%coarse_graining_attrs%strategy) .eq. MODEL_LEVEL) then
        call fv_coarse_diag_model_levels(Atm, Time)
     else
        write(error_message, *) 'Invalid coarse_graining_strategy provided.'

--- a/FV3/atmos_cubed_sphere/tools/coarse_grained_diagnostics.F90
+++ b/FV3/atmos_cubed_sphere/tools/coarse_grained_diagnostics.F90
@@ -12,6 +12,8 @@ module coarse_grained_diagnostics_mod
   
   public :: fv_coarse_diag_init, fv_coarse_diag
 
+  integer :: tile_count = 1  ! Following fv_diagnostics.F90
+
 contains
   
   subroutine fv_coarse_diag_init(Atm, coarse_axes_t, Time)
@@ -24,13 +26,11 @@ contains
     integer :: is, ie, js, je, is_coarse, ie_coarse, js_coarse, je_coarse
     integer :: npz
     integer :: id_coarse_x, id_coarse_y, id_coarse_xt, id_coarse_yt
-    integer :: tile_count
     integer :: coarse_axes(4)
     integer :: id_pfull, id_phalf
     real :: missing_value
 
     missing_value = -1.0e10  ! Following fv_diagnostics.F90
-    tile_count = 1  ! Following fv_diagnostics.F90
 
     target_resolution = Atm(tile_count)%coarse_graining_attributes%target_coarse_resolution
     coarse_domain = Atm(tile_count)%coarse_graining_attributes%coarse_domain
@@ -39,8 +39,7 @@ contains
     npz = Atm(tile_count)%npz
     
     call initialize_coarse_diagnostic_axes(coarse_domain, &
-         target_resolution, tile_count, &
-         id_coarse_x, id_coarse_y, id_coarse_xt, id_coarse_yt)
+         target_resolution, id_coarse_x, id_coarse_y, id_coarse_xt, id_coarse_yt)
 
     id_pfull = Atm(tile_count)%atmos_axes(3)
     id_phalf = Atm(tile_count)%atmos_axes(4)
@@ -62,10 +61,9 @@ contains
   end subroutine fv_coarse_diag_init
 
   subroutine initialize_coarse_diagnostic_axes(coarse_domain, &
-    target_resolution, tile_count, &
-    id_coarse_x, id_coarse_y, id_coarse_xt, id_coarse_yt)
+    target_resolution, id_coarse_x, id_coarse_y, id_coarse_xt, id_coarse_yt)
     type(domain2d), intent(in) :: coarse_domain
-    integer, intent(in) :: target_resolution, tile_count
+    integer, intent(in) :: target_resolution
     integer, intent(out) :: id_coarse_x, id_coarse_y, id_coarse_xt, id_coarse_yt
 
     integer :: i, j
@@ -102,9 +100,7 @@ contains
     type(time_type), intent(in) :: Time
  
     character(len=256) :: error_message
-    integer :: tile_count
 
-    tile_count = 1  ! Following fv_diag
     if (trim(Atm(tile_count)%coarse_graining_attributes%coarse_graining_strategy) .eq. MODEL_LEVEL) then
        call fv_coarse_diag_model_levels(Atm, Time)
     else
@@ -119,10 +115,8 @@ contains
     
     real, allocatable :: work_3d_coarse(:,:,:)
     integer :: is, ie, js, je, is_coarse, ie_coarse, js_coarse, je_coarse, npz
-    integer :: tile_count
     logical :: used
 
-    tile_count = 1  ! Following fv_diag
     call get_fine_array_bounds(Atm(tile_count), is, ie, js, je)
     call get_coarse_array_bounds(Atm(tile_count), is_coarse, ie_coarse, js_coarse, je_coarse)
     npz = Atm(tile_count)%npz

--- a/FV3/atmos_cubed_sphere/tools/coarse_grained_diagnostics.F90
+++ b/FV3/atmos_cubed_sphere/tools/coarse_grained_diagnostics.F90
@@ -57,17 +57,17 @@ contains
     grid_yt_coarse = (/ (j, j=1, nx_coarse) /)
     
     id_x_coarse = diag_axis_init('grid_x_coarse', grid_x_coarse, &
-         'degrees_E', 'x', 'Corner longitude', set_name='coarse_grid', &
+         'index', 'x', 'x-index of cell corner points', set_name='coarse_grid', &
          Domain2=coarse_domain, tile_count=tile_count)
     id_y_coarse = diag_axis_init('grid_y_coarse', grid_y_coarse, &
-         'degrees_N', 'y', 'Corner latitude', set_name='coarse_grid', &
+         'index', 'y', 'y-index of cell corner points', set_name='coarse_grid', &
          Domain2=coarse_domain, tile_count=tile_count)
 
     id_xt_coarse = diag_axis_init('grid_xt_coarse', grid_xt_coarse, &
-         'degrees_E', 'x', 'T-cell longitude', set_name='coarse_grid', &
+         'index', 'x', 'x-index of cell center points', set_name='coarse_grid', &
          Domain2=coarse_domain, tile_count=tile_count)
     id_yt_coarse = diag_axis_init('grid_yt_coarse', grid_yt_coarse, &
-         'degrees_N', 'y', 'T-cell latitude', set_name='coarse_grid', &
+         'index', 'y', 'y-index of cell center points', set_name='coarse_grid', &
          Domain2=coarse_domain, tile_count=tile_count)    
   end subroutine initialize_coarse_diagnostic_axes
   
@@ -95,10 +95,7 @@ contains
 
     if (trim(Atm(tile_count)%coarse_graining%strategy) .eq. MODEL_LEVEL) then
        call fv_coarse_diag_model_levels(Atm, Time)
-    else
-       write(error_message, *) 'Invalid coarse_graining_strategy provided.'
-       call mpp_error(FATAL, error_message)
-    endif    
+    endif
   end subroutine fv_coarse_diag
   
   subroutine fv_coarse_diag_model_levels(Atm, Time)

--- a/FV3/atmos_cubed_sphere/tools/coarse_grained_diagnostics.F90
+++ b/FV3/atmos_cubed_sphere/tools/coarse_grained_diagnostics.F90
@@ -4,7 +4,7 @@ module coarse_grained_diagnostics_mod
   use fv_arrays_mod, only: fv_atmos_type, fv_coarse_diag_type
   use mpp_domains_mod, only: domain2d
   use mpp_mod, only: FATAL, mpp_error
-  use online_coarse_graining_mod, only: MODEL_LEVEL, weighted_block_average
+  use online_coarse_graining_mod, only: block_sum, get_fine_array_bounds, get_coarse_array_bounds, MODEL_LEVEL, weighted_block_average
   use time_manager_mod, only: time_type
   
   implicit none
@@ -48,7 +48,7 @@ contains
 
     call register_coarse_static_diagnostics(Atm, Time, coarse_axes_t, coarse_axes)
     call register_coarse_diagnostics(Atm, Time, coarse_axes_t)
-    call compute_static_diagnostics(Atm, Time)
+    call compute_coarse_static_diagnostics(Atm, Time)
   end subroutine fv_coarse_diag_init
 
   subroutine initialize_coarse_diagnostic_axes(coarse_domain, &
@@ -200,24 +200,4 @@ contains
     diagnostic_ids_3d = (/ Atm(tile_count)%idiag_coarse%id_omega_coarse /)
   end subroutine 
   
-  subroutine get_fine_array_bounds(Atm, is, ie, js, je)
-    type(fv_atmos_type), intent(in) :: Atm
-    integer, intent(out) :: is, ie, js, je
-
-    is = Atm%bd%is
-    ie = Atm%bd%ie
-    js = Atm%bd%js
-    je = Atm%bd%je
-  end subroutine get_fine_array_bounds
-  
-  subroutine get_coarse_array_bounds(Atm, is_coarse, ie_coarse, js_coarse, je_coarse)
-    type(fv_atmos_type), intent(in) :: Atm
-    integer, intent(out) :: is_coarse, ie_coarse, js_coarse, je_coarse
-
-    is_coarse = Atm%coarse_graining_attributes%coarse_bd%is_coarse
-    ie_coarse = Atm%coarse_graining_attributes%coarse_bd%ie_coarse
-    js_coarse = Atm%coarse_graining_attributes%coarse_bd%js_coarse
-    je_coarse = Atm%coarse_graining_attributes%coarse_bd%je_coarse
-  end subroutine get_coarse_array_bounds
-
 end module coarse_grained_diagnostics_mod

--- a/FV3/atmos_cubed_sphere/tools/coarse_grained_diagnostics.F90
+++ b/FV3/atmos_cubed_sphere/tools/coarse_grained_diagnostics.F90
@@ -1,6 +1,6 @@
 module coarse_grained_diagnostics_mod
 
-  use diag_manager_mod, only: diag_axis_init, register_diag_field, send_data
+  use diag_manager_mod, only: diag_axis_init, register_diag_field, register_static_field, send_data
   use fv_arrays_mod, only: fv_atmos_type, fv_coarse_diag_type
   use mpp_domains_mod, only: domain2d
   use mpp_mod, only: FATAL, mpp_error
@@ -21,50 +21,41 @@ contains
     integer, intent(out) :: coarse_axes_t(4)
     type(time_type), intent(in) :: Time
 
-    type(domain2d) :: coarse_domain
-    integer :: target_resolution
     integer :: is, ie, js, je, is_coarse, ie_coarse, js_coarse, je_coarse
-    integer :: npz
-    integer :: id_coarse_x, id_coarse_y, id_coarse_xt, id_coarse_yt
+    integer :: id_x_coarse, id_y_coarse, id_xt_coarse, id_yt_coarse
     integer :: coarse_axes(4)
     integer :: id_pfull, id_phalf
-    real :: missing_value
 
-    missing_value = -1.0e10  ! Following fv_diagnostics.F90
-
-    target_resolution = Atm(tile_count)%coarse_graining_attributes%target_coarse_resolution
-    coarse_domain = Atm(tile_count)%coarse_graining_attributes%coarse_domain
     call get_fine_array_bounds(Atm(tile_count), is, ie, js, je)
-    call get_coarse_array_bounds(Atm(tile_count), is_coarse, ie_coarse, js_coarse, je_coarse)
-    npz = Atm(tile_count)%npz
-    
-    call initialize_coarse_diagnostic_axes(coarse_domain, &
-         target_resolution, id_coarse_x, id_coarse_y, id_coarse_xt, id_coarse_yt)
+    call get_coarse_array_bounds(Atm(tile_count), is_coarse, ie_coarse, js_coarse, je_coarse)    
+    call initialize_coarse_diagnostic_axes( &
+         Atm(tile_count)%coarse_graining_attributes%coarse_domain, &
+         Atm(tile_count)%coarse_graining_attributes%target_coarse_resolution, &         
+         id_x_coarse, id_y_coarse, id_xt_coarse, id_yt_coarse)
 
     id_pfull = Atm(tile_count)%atmos_axes(3)
     id_phalf = Atm(tile_count)%atmos_axes(4)
     
-    coarse_axes(1) = id_coarse_x
-    coarse_axes(2) = id_coarse_y
+    coarse_axes(1) = id_x_coarse
+    coarse_axes(2) = id_y_coarse
     coarse_axes(3) = id_pfull
     coarse_axes(4) = id_phalf
 
-    coarse_axes_t(1) = id_coarse_xt
-    coarse_axes_t(2) = id_coarse_yt
+    coarse_axes_t(1) = id_xt_coarse
+    coarse_axes_t(2) = id_yt_coarse
     coarse_axes_t(3) = id_pfull
     coarse_axes_t(4) = id_phalf
-    
-    Atm(tile_count)%idiag_coarse%id_omega_coarse = register_diag_field('dynamics', &
-         'omega_coarse', coarse_axes_t(1:3), Time, &
-         'coarse-grained omega', &
-         'Pa/s', missing_value=missing_value)
+
+    call register_coarse_static_diagnostics(Atm, Time, coarse_axes_t, coarse_axes)
+    call register_coarse_diagnostics(Atm, Time, coarse_axes_t)
+    call compute_static_diagnostics(Atm, Time)
   end subroutine fv_coarse_diag_init
 
   subroutine initialize_coarse_diagnostic_axes(coarse_domain, &
-    target_resolution, id_coarse_x, id_coarse_y, id_coarse_xt, id_coarse_yt)
+    target_resolution, id_x_coarse, id_y_coarse, id_xt_coarse, id_yt_coarse)
     type(domain2d), intent(in) :: coarse_domain
     integer, intent(in) :: target_resolution
-    integer, intent(out) :: id_coarse_x, id_coarse_y, id_coarse_xt, id_coarse_yt
+    integer, intent(out) :: id_x_coarse, id_y_coarse, id_xt_coarse, id_yt_coarse
 
     integer :: i, j
     real, allocatable :: grid_x_coarse(:), grid_y_coarse(:), grid_xt_coarse(:), grid_yt_coarse(:)
@@ -79,22 +70,88 @@ contains
     grid_xt_coarse = (/ (i, i=1, target_resolution) /)
     grid_yt_coarse = (/ (j, j=1, target_resolution) /)
     
-    id_coarse_x = diag_axis_init('grid_x_coarse', grid_x_coarse, &
+    id_x_coarse = diag_axis_init('grid_x_coarse', grid_x_coarse, &
          'degrees_E', 'x', 'Corner longitude', set_name='coarse_grid', &
          Domain2=coarse_domain, tile_count=tile_count)
-    id_coarse_y = diag_axis_init('grid_y_coarse', grid_y_coarse, &
+    id_y_coarse = diag_axis_init('grid_y_coarse', grid_y_coarse, &
          'degrees_N', 'y', 'Corner latitude', set_name='coarse_grid', &
          Domain2=coarse_domain, tile_count=tile_count)
 
-    id_coarse_xt = diag_axis_init('grid_xt_coarse', grid_xt_coarse, &
+    id_xt_coarse = diag_axis_init('grid_xt_coarse', grid_xt_coarse, &
          'degrees_E', 'x', 'T-cell longitude', set_name='coarse_grid', &
          Domain2=coarse_domain, tile_count=tile_count)
-    id_coarse_yt = diag_axis_init('grid_yt_coarse', grid_yt_coarse, &
+    id_yt_coarse = diag_axis_init('grid_yt_coarse', grid_yt_coarse, &
          'degrees_N', 'y', 'T-cell latitude', set_name='coarse_grid', &
-         Domain2=coarse_domain, tile_count=tile_count)
-    
+         Domain2=coarse_domain, tile_count=tile_count)    
   end subroutine initialize_coarse_diagnostic_axes
 
+  subroutine register_coarse_static_diagnostics(Atm, Time, coarse_axes_t, coarse_axes)
+    type(fv_atmos_type), intent(inout) :: Atm(:)
+    type(time_type), intent(in) :: Time
+    integer, intent(in) :: coarse_axes_t(4), coarse_axes(4)
+    integer :: id_x_coarse, id_xt_coarse, id_y_coarse, id_yt_coarse
+
+    id_x_coarse = coarse_axes(1)
+    id_y_coarse = coarse_axes(2)
+    id_xt_coarse = coarse_axes_t(1)
+    id_yt_coarse = coarse_axes_t(2)
+
+    Atm(tile_count)%idiag_coarse%id_grid_lont_coarse = register_static_field( &
+         'dynamics', 'grid_lont_coarse', coarse_axes_t(1:2), &
+         'longitude', 'degrees_E')    
+    Atm(tile_count)%idiag_coarse%id_grid_lon_coarse = register_static_field( &
+         'dynamics', 'grid_lon_coarse', coarse_axes(1:2), &
+         'longitude', 'degrees_E')
+    Atm(tile_count)%idiag_coarse%id_grid_latt_coarse = register_static_field( &
+         'dynamics', 'grid_latt_coarse', coarse_axes_t(1:2), &
+         'latitude', 'degrees_N')    
+    Atm(tile_count)%idiag_coarse%id_grid_lat_coarse = register_static_field( &
+         'dynamics', 'grid_lat_coarse', coarse_axes(1:2), &
+         'latitude', 'degrees_N')
+    Atm(tile_count)%idiag_coarse%id_area_coarse = register_static_field( &
+         'dynamics', 'area_coarse', coarse_axes_t(1:2), &
+         'cell area', 'm**2')
+    Atm(tile_count)%idiag_coarse%id_dx_coarse = register_static_field( &
+         'dynamics', 'dx_coarse', (/ id_xt_coarse, id_y_coarse /), &
+         'dx', 'm')
+    Atm(tile_count)%idiag_coarse%id_dy_coarse = register_static_field( &
+         'dynamics', 'dy_coarse', (/ id_x_coarse, id_yt_coarse /), &
+         'dy', 'm')
+  end subroutine register_coarse_static_diagnostics
+
+  subroutine compute_coarse_static_diagnostics(Atm, Time)
+    type(fv_atmos_type), intent(inout) :: Atm(:)
+    type(time_type), intent(in) :: Time
+    
+    real, allocatable :: work_2d_coarse(:,:)
+    integer :: is, ie, js, je, is_coarse, ie_coarse, js_coarse, je_coarse, npz
+    logical :: used
+
+    call get_fine_array_bounds(Atm(tile_count), is, ie, js, je)
+    call get_coarse_array_bounds(Atm(tile_count), is_coarse, ie_coarse, js_coarse, je_coarse)
+    
+    if (Atm(tile_count)%idiag_coarse%id_area_coarse > 0) then
+       allocate(work_2d_coarse(is_coarse:ie_coarse,js_coarse:je_coarse))
+       call block_sum(Atm(tile_count)%gridstruct%area(is:ie,js:je), work_2d_coarse)
+       used = send_data(Atm(tile_count)%idiag_coarse%id_area_coarse, work_2d_coarse, Time)
+    endif
+
+    ! TODO implement the other static diagnostics.
+  end subroutine compute_coarse_static_diagnostics
+  
+  subroutine register_coarse_diagnostics(Atm, Time, coarse_axes_t)
+    type(fv_atmos_type), intent(inout) :: Atm(:)
+    type(time_type), intent(in) :: Time
+    integer, intent(in) :: coarse_axes_t(4)
+
+    real :: missing_value = -1.0e10  ! Following fv_diagnostics.F90
+    
+    Atm(tile_count)%idiag_coarse%id_omega_coarse = register_diag_field('dynamics', &
+         'omega_coarse', coarse_axes_t(1:3), Time, &
+         'coarse-grained omega', &
+         'Pa/s', missing_value=missing_value)
+  end subroutine register_coarse_diagnostics
+  
   subroutine fv_coarse_diag(Atm, Time)
     type(fv_atmos_type), intent(in), target :: Atm(:)
     type(time_type), intent(in) :: Time
@@ -114,14 +171,18 @@ contains
     type(time_type), intent(in) :: Time
     
     real, allocatable :: work_3d_coarse(:,:,:)
+    integer :: diagnostic_ids_3d(Atm(tile_count)%idiag_coarse%n_3d_diagnostics)
     integer :: is, ie, js, je, is_coarse, ie_coarse, js_coarse, je_coarse, npz
     logical :: used
 
+    call get_diagnostic_ids_3d(Atm, diagnostic_ids_3d)
     call get_fine_array_bounds(Atm(tile_count), is, ie, js, je)
     call get_coarse_array_bounds(Atm(tile_count), is_coarse, ie_coarse, js_coarse, je_coarse)
     npz = Atm(tile_count)%npz
 
-    allocate(work_3d_coarse(is_coarse:ie_coarse,js_coarse:je_coarse,1:npz))
+    if (any(diagnostic_ids_3d > 0)) then
+       allocate(work_3d_coarse(is_coarse:ie_coarse,js_coarse:je_coarse,1:npz))       
+    endif
 
     if (Atm(tile_count)%idiag_coarse%id_omega_coarse > 0) then
        call weighted_block_average( &
@@ -132,6 +193,13 @@ contains
     endif    
   end subroutine fv_coarse_diag_model_levels
 
+  subroutine get_diagnostic_ids_3d(Atm, diagnostic_ids_3d)
+    type(fv_atmos_type), intent(in) :: Atm(:)
+    integer, intent(out) :: diagnostic_ids_3d(Atm(tile_count)%idiag_coarse%n_3d_diagnostics)
+
+    diagnostic_ids_3d = (/ Atm(tile_count)%idiag_coarse%id_omega_coarse /)
+  end subroutine 
+  
   subroutine get_fine_array_bounds(Atm, is, ie, js, je)
     type(fv_atmos_type), intent(in) :: Atm
     integer, intent(out) :: is, ie, js, je

--- a/FV3/atmos_cubed_sphere/tools/coarse_grained_diagnostics.F90
+++ b/FV3/atmos_cubed_sphere/tools/coarse_grained_diagnostics.F90
@@ -1,0 +1,178 @@
+module coarse_grained_diagnostics_mod
+
+  use diag_manager_mod, only: diag_axis_init, register_diag_field, send_data
+  use fv_arrays_mod, only: fv_atmos_type, fv_coarse_diag_type
+  use mpp_domains_mod, only: domain2d
+  use online_coarse_graining_mod, only: weighted_block_average
+  use time_manager_mod, only: time_type
+  
+  implicit none
+  private
+  
+  public :: fv_coarse_diag_init, fv_coarse_diag
+
+contains
+
+  subroutine fv_coarse_diag_init(Atm, coarse_axes_t, Time)
+    type(fv_atmos_type), intent(inout) :: Atm(:)
+    integer, intent(inout) :: coarse_axes_t(4)
+    type(time_type), intent(in) :: Time
+    type(domain2d) :: coarse_domain
+    integer :: tile_count
+    integer :: is, ie, js, je, is_coarse, ie_coarse, js_coarse, je_coarse
+    integer :: npz, target_resolution
+    
+    tile_count = 1
+    target_resolution = Atm(tile_count)%target_coarse_resolution
+    coarse_domain = Atm(tile_count)%coarse_domain
+
+    call get_fine_array_bounds(Atm(tile_count), is, ie, js, je)
+    call get_coarse_array_bounds(Atm(tile_count), is_coarse, ie_coarse, js_coarse, je_coarse)
+    npz = Atm(tile_count)%npz
+    
+    call register_coarse_grained_diagnostics(Atm, coarse_axes_t, Time, &
+         coarse_domain, target_resolution, is, ie, js, je, is_coarse, &
+         ie_coarse, js_coarse, je_coarse, npz)
+  end subroutine fv_coarse_diag_init
+
+  subroutine fv_coarse_diag(Atm, Time)
+    type(fv_atmos_type), intent(inout) :: Atm(:)
+    type(time_type), intent(in) :: Time
+    integer :: tile_count
+    integer :: is, ie, js, je, is_coarse, ie_coarse, js_coarse, je_coarse
+    integer :: npz
+ 
+    tile_count = 1
+
+    call get_fine_array_bounds(Atm(tile_count), is, ie, js, je)
+    call get_coarse_array_bounds(Atm(tile_count), is_coarse, ie_coarse, js_coarse, je_coarse)
+    npz = Atm(tile_count)%npz
+    
+    call compute_coarse_grained_diagnostics(Atm, Time, is, ie, js, je, &
+         is_coarse, ie_coarse, js_coarse, je_coarse, npz)
+  end subroutine fv_coarse_diag
+  
+  subroutine register_coarse_grained_diagnostics(Atm, coarse_axes_t, Time, &
+         coarse_domain, target_resolution, is, ie, js, je, is_coarse, &
+         ie_coarse, js_coarse, je_coarse, npz)
+    type(fv_atmos_type), intent(inout) :: Atm(:)
+    integer, intent(out) :: coarse_axes_t(4)
+    type(time_type), intent(in) :: Time
+    type(domain2d), intent(in) :: coarse_domain
+    integer, intent(in) :: target_resolution
+    integer, intent(in) :: is, ie, js, je
+    integer, intent(in) :: is_coarse, ie_coarse, js_coarse, je_coarse
+    integer, intent(in) :: npz
+
+    integer :: id_coarse_x, id_coarse_y, id_coarse_xt, id_coarse_yt
+    integer :: tile_count
+    integer :: coarse_axes(4)
+    integer :: id_pfull, id_phalf
+    real :: missing_value
+
+    missing_value = -1.0e10  ! Following fv_diagnostics.F90
+    tile_count = 1  ! Following fv_diagnostics.F90
+    
+    call initialize_coarse_diagnostic_axes(coarse_domain, &
+         target_resolution, tile_count, &
+         id_coarse_x, id_coarse_y, id_coarse_xt, id_coarse_yt)
+
+    id_pfull = Atm(tile_count)%atmos_axes(3)
+    id_phalf = Atm(tile_count)%atmos_axes(4)
+    
+    coarse_axes(1) = id_coarse_x
+    coarse_axes(2) = id_coarse_y
+    coarse_axes(3) = id_pfull
+    coarse_axes(4) = id_phalf
+
+    coarse_axes_t(1) = id_coarse_xt
+    coarse_axes_t(2) = id_coarse_yt
+    coarse_axes_t(3) = id_pfull
+    coarse_axes_t(4) = id_phalf
+    
+    Atm(tile_count)%idiag_coarse%id_omega_coarse = register_diag_field('dynamics', &
+         'omega_coarse', coarse_axes_t(1:3), Time, &
+         'coarse-grained omega', &
+         'Pa/s', missing_value=missing_value)
+  end subroutine register_coarse_grained_diagnostics
+
+  subroutine initialize_coarse_diagnostic_axes(coarse_domain, &
+    target_resolution, tile_count, &
+    id_coarse_x, id_coarse_y, id_coarse_xt, id_coarse_yt)
+    type(domain2d), intent(in) :: coarse_domain
+    integer, intent(in) :: target_resolution, tile_count
+    integer, intent(out) :: id_coarse_x, id_coarse_y, id_coarse_xt, id_coarse_yt
+
+    integer :: i, j
+    real, allocatable :: grid_x_coarse(:), grid_y_coarse(:), grid_xt_coarse(:), grid_yt_coarse(:)
+
+    allocate(grid_x_coarse(target_resolution + 1))
+    allocate(grid_y_coarse(target_resolution + 1))
+    allocate(grid_xt_coarse(target_resolution))
+    allocate(grid_yt_coarse(target_resolution))
+
+    grid_x_coarse = (/ (i, i=1, target_resolution + 1) /)
+    grid_y_coarse = (/ (j, j=1, target_resolution + 1) /)
+    grid_xt_coarse = (/ (i, i=1, target_resolution) /)
+    grid_yt_coarse = (/ (j, j=1, target_resolution) /)
+    
+    id_coarse_x = diag_axis_init('grid_x_coarse', grid_x_coarse, &
+         'degrees_E', 'x', 'Corner longitude', set_name='coarse_grid', &
+         Domain2=coarse_domain, tile_count=tile_count)
+    id_coarse_y = diag_axis_init('grid_y_coarse', grid_y_coarse, &
+         'degrees_N', 'y', 'Corner latitude', set_name='coarse_grid', &
+         Domain2=coarse_domain, tile_count=tile_count)
+
+    id_coarse_xt = diag_axis_init('grid_xt_coarse', grid_xt_coarse, &
+         'degrees_E', 'x', 'T-cell longitude', set_name='coarse_grid', &
+         Domain2=coarse_domain, tile_count=tile_count)
+    id_coarse_yt = diag_axis_init('grid_yt_coarse', grid_yt_coarse, &
+         'degrees_N', 'y', 'T-cell latitude', set_name='coarse_grid', &
+         Domain2=coarse_domain, tile_count=tile_count)
+    
+  end subroutine initialize_coarse_diagnostic_axes
+
+  subroutine compute_coarse_grained_diagnostics(Atm, Time, is, ie, js, je,&
+       & is_coarse, ie_coarse, js_coarse, je_coarse, npz)
+    type(fv_atmos_type), intent(in), target :: Atm(:)
+    type(time_type), intent(in) :: Time
+    integer, intent(in) :: is, ie, js, je, is_coarse, ie_coarse, js_coarse, je_coarse
+    integer, intent(in) :: npz
+    
+    real, allocatable :: work_3d_coarse(:,:,:)
+    logical :: used
+    integer :: tile_count
+
+    tile_count = 1  ! Following fv_diag
+    allocate(work_3d_coarse(is_coarse:ie_coarse,js_coarse:je_coarse,1:npz))
+
+    if (Atm(tile_count)%idiag_coarse%id_omega_coarse > 0) then
+       call weighted_block_average( &
+            Atm(tile_count)%gridstruct%area(is:ie,js:je), &
+            Atm(tile_count)%omga(is:ie,js:je,1:npz), &
+            work_3d_coarse)
+       used = send_data(Atm(tile_count)%idiag_coarse%id_omega_coarse, work_3d_coarse, Time)
+    endif    
+  end subroutine compute_coarse_grained_diagnostics
+
+  subroutine get_fine_array_bounds(Atm, is, ie, js, je)
+    type(fv_atmos_type), intent(in) :: Atm
+    integer, intent(out) :: is, ie, js, je
+
+    is = Atm%bd%is
+    ie = Atm%bd%ie
+    js = Atm%bd%js
+    je = Atm%bd%je
+  end subroutine get_fine_array_bounds
+  
+  subroutine get_coarse_array_bounds(Atm, is_coarse, ie_coarse, js_coarse, je_coarse)
+    type(fv_atmos_type), intent(in) :: Atm
+    integer, intent(out) :: is_coarse, ie_coarse, js_coarse, je_coarse
+
+    is_coarse = Atm%coarse_bd%is_coarse
+    ie_coarse = Atm%coarse_bd%ie_coarse
+    js_coarse = Atm%coarse_bd%js_coarse
+    je_coarse = Atm%coarse_bd%je_coarse
+  end subroutine get_coarse_array_bounds
+
+end module coarse_grained_diagnostics_mod

--- a/FV3/atmos_cubed_sphere/tools/coarse_grained_diagnostics.F90
+++ b/FV3/atmos_cubed_sphere/tools/coarse_grained_diagnostics.F90
@@ -1,10 +1,10 @@
 module coarse_grained_diagnostics_mod
 
   use diag_manager_mod, only: diag_axis_init, register_diag_field, register_static_field, send_data
-  use fv_arrays_mod, only: fv_atmos_type, fv_coarse_diag_type
+  use fv_arrays_mod, only: fv_atmos_type, fv_coarse_diag_type, fv_coarse_graining_type, fv_grid_bounds_type
   use mpp_domains_mod, only: domain2d
   use mpp_mod, only: FATAL, mpp_error
-  use online_coarse_graining_mod, only: block_sum, get_fine_array_bounds, get_coarse_array_bounds, MODEL_LEVEL, weighted_block_average
+  use coarse_graining_mod, only: block_sum, get_fine_array_bounds, get_coarse_array_bounds, MODEL_LEVEL, weighted_block_average
   use time_manager_mod, only: time_type
   
   implicit none
@@ -16,60 +16,45 @@ module coarse_grained_diagnostics_mod
 
 contains
   
-  subroutine fv_coarse_diag_init(Atm, coarse_axes_t, Time)
-    type(fv_atmos_type), intent(inout) :: Atm(:)
-    integer, intent(out) :: coarse_axes_t(4)
+  subroutine fv_coarse_diag_init(bd, Time, id_pfull, id_phalf, coarse_graining)
+    type(fv_grid_bounds_type), intent(in) :: bd
     type(time_type), intent(in) :: Time
+    integer, intent(in) :: id_pfull, id_phalf
+    type(fv_coarse_graining_type), intent(inout) :: coarse_graining
 
     integer :: is, ie, js, je, is_coarse, ie_coarse, js_coarse, je_coarse
-    integer :: id_x_coarse, id_y_coarse, id_xt_coarse, id_yt_coarse
-    integer :: coarse_axes(4)
-    integer :: id_pfull, id_phalf
 
-    call get_fine_array_bounds(Atm(tile_count), is, ie, js, je)
-    call get_coarse_array_bounds(Atm(tile_count), is_coarse, ie_coarse, js_coarse, je_coarse)    
-    call initialize_coarse_diagnostic_axes( &
-         Atm(tile_count)%coarse_graining_attrs%domain, &
-         Atm(tile_count)%coarse_graining_attrs%target_resolution, &         
-         id_x_coarse, id_y_coarse, id_xt_coarse, id_yt_coarse)
+    call get_fine_array_bounds(bd, is, ie, js, je)
+    call get_coarse_array_bounds(coarse_graining%bd, is_coarse, ie_coarse, js_coarse, je_coarse)    
+    call initialize_coarse_diagnostic_axes(coarse_graining%domain, coarse_graining%nx_coarse, &
+         coarse_graining%id_x_coarse, coarse_graining%id_y_coarse, coarse_graining%id_xt_coarse, &
+         coarse_graining%id_yt_coarse)
+    
+    coarse_graining%id_pfull = id_pfull
+    coarse_graining%id_phalf = id_phalf
 
-    id_pfull = Atm(tile_count)%atmos_axes(3)
-    id_phalf = Atm(tile_count)%atmos_axes(4)
-
-    ! We don't use these in this minimal example, but they will be needed
-    ! later.  These are the axes for variables that live on grid cell edges.
-    coarse_axes(1) = id_x_coarse
-    coarse_axes(2) = id_y_coarse
-    coarse_axes(3) = id_pfull
-    coarse_axes(4) = id_phalf
-
-    ! These are the axes for values that live on grid cell centers.
-    coarse_axes_t(1) = id_xt_coarse
-    coarse_axes_t(2) = id_yt_coarse
-    coarse_axes_t(3) = id_pfull
-    coarse_axes_t(4) = id_phalf
-
-    call register_coarse_diagnostics(Atm, Time, coarse_axes_t)
+    call register_coarse_diagnostics(coarse_graining%idiag, Time, &
+         coarse_graining%id_xt_coarse, coarse_graining%id_yt_coarse, id_pfull)
   end subroutine fv_coarse_diag_init
 
   subroutine initialize_coarse_diagnostic_axes(coarse_domain, &
-    target_resolution, id_x_coarse, id_y_coarse, id_xt_coarse, id_yt_coarse)
+    nx_coarse, id_x_coarse, id_y_coarse, id_xt_coarse, id_yt_coarse)
     type(domain2d), intent(in) :: coarse_domain
-    integer, intent(in) :: target_resolution
-    integer, intent(out) :: id_x_coarse, id_y_coarse, id_xt_coarse, id_yt_coarse
+    integer, intent(in) :: nx_coarse
+    integer, intent(inout) :: id_x_coarse, id_y_coarse, id_xt_coarse, id_yt_coarse
 
     integer :: i, j
     real, allocatable :: grid_x_coarse(:), grid_y_coarse(:), grid_xt_coarse(:), grid_yt_coarse(:)
 
-    allocate(grid_x_coarse(target_resolution + 1))
-    allocate(grid_y_coarse(target_resolution + 1))
-    allocate(grid_xt_coarse(target_resolution))
-    allocate(grid_yt_coarse(target_resolution))
+    allocate(grid_x_coarse(nx_coarse + 1))
+    allocate(grid_y_coarse(nx_coarse + 1))
+    allocate(grid_xt_coarse(nx_coarse))
+    allocate(grid_yt_coarse(nx_coarse))
 
-    grid_x_coarse = (/ (i, i=1, target_resolution + 1) /)
-    grid_y_coarse = (/ (j, j=1, target_resolution + 1) /)
-    grid_xt_coarse = (/ (i, i=1, target_resolution) /)
-    grid_yt_coarse = (/ (j, j=1, target_resolution) /)
+    grid_x_coarse = (/ (i, i=1, nx_coarse + 1) /)
+    grid_y_coarse = (/ (j, j=1, nx_coarse + 1) /)
+    grid_xt_coarse = (/ (i, i=1, nx_coarse) /)
+    grid_yt_coarse = (/ (j, j=1, nx_coarse) /)
     
     id_x_coarse = diag_axis_init('grid_x_coarse', grid_x_coarse, &
          'degrees_E', 'x', 'Corner longitude', set_name='coarse_grid', &
@@ -86,14 +71,17 @@ contains
          Domain2=coarse_domain, tile_count=tile_count)    
   end subroutine initialize_coarse_diagnostic_axes
   
-  subroutine register_coarse_diagnostics(Atm, Time, coarse_axes_t)
-    type(fv_atmos_type), intent(inout) :: Atm(:)
+  subroutine register_coarse_diagnostics(idiag_coarse, Time, id_xt_coarse,&
+       id_yt_coarse, id_pfull)
+    type(fv_coarse_diag_type), intent(inout) :: idiag_coarse
     type(time_type), intent(in) :: Time
-    integer, intent(in) :: coarse_axes_t(4)
+    integer, intent(in) :: id_xt_coarse, id_yt_coarse, id_pfull
 
+    integer :: coarse_axes_t(3)
     real :: missing_value = -1.0e10  ! Following fv_diagnostics.F90
-    
-    Atm(tile_count)%idiag_coarse%id_omega_coarse = register_diag_field('dynamics', &
+
+    coarse_axes_t = (/ id_xt_coarse, id_yt_coarse, id_pfull /)
+    idiag_coarse%id_omega_coarse = register_diag_field('dynamics', &
          'omega_coarse', coarse_axes_t(1:3), Time, &
          'coarse-grained omega', &
          'Pa/s', missing_value=missing_value)
@@ -105,7 +93,7 @@ contains
  
     character(len=256) :: error_message
 
-    if (trim(Atm(tile_count)%coarse_graining_attrs%strategy) .eq. MODEL_LEVEL) then
+    if (trim(Atm(tile_count)%coarse_graining%strategy) .eq. MODEL_LEVEL) then
        call fv_coarse_diag_model_levels(Atm, Time)
     else
        write(error_message, *) 'Invalid coarse_graining_strategy provided.'
@@ -118,33 +106,33 @@ contains
     type(time_type), intent(in) :: Time
     
     real, allocatable :: work_3d_coarse(:,:,:)
-    integer :: diagnostic_ids_3d(Atm(tile_count)%idiag_coarse%n_3d_diagnostics)
+    integer :: diagnostic_ids_3d(Atm(tile_count)%coarse_graining%idiag%n_3d_diagnostics)
     integer :: is, ie, js, je, is_coarse, ie_coarse, js_coarse, je_coarse, npz
     logical :: used
 
-    call get_diagnostic_ids_3d(Atm, diagnostic_ids_3d)
-    call get_fine_array_bounds(Atm(tile_count), is, ie, js, je)
-    call get_coarse_array_bounds(Atm(tile_count), is_coarse, ie_coarse, js_coarse, je_coarse)
+    call get_diagnostic_ids_3d(Atm(tile_count)%coarse_graining%idiag, diagnostic_ids_3d)
+    call get_fine_array_bounds(Atm(tile_count)%bd, is, ie, js, je)
+    call get_coarse_array_bounds(Atm(tile_count)%coarse_graining%bd, is_coarse, ie_coarse, js_coarse, je_coarse)
     npz = Atm(tile_count)%npz
 
     if (any(diagnostic_ids_3d > 0)) then
        allocate(work_3d_coarse(is_coarse:ie_coarse,js_coarse:je_coarse,1:npz))       
     endif
 
-    if (Atm(tile_count)%idiag_coarse%id_omega_coarse > 0) then
+    if (Atm(tile_count)%coarse_graining%idiag%id_omega_coarse > 0) then
        call weighted_block_average( &
             Atm(tile_count)%gridstruct%area(is:ie,js:je), &
             Atm(tile_count)%omga(is:ie,js:je,1:npz), &
             work_3d_coarse)
-       used = send_data(Atm(tile_count)%idiag_coarse%id_omega_coarse, work_3d_coarse, Time)
+       used = send_data(Atm(tile_count)%coarse_graining%idiag%id_omega_coarse, work_3d_coarse, Time)
     endif    
   end subroutine fv_coarse_diag_model_levels
   
-  subroutine get_diagnostic_ids_3d(Atm, diagnostic_ids_3d)
-    type(fv_atmos_type), intent(in) :: Atm(:)
-    integer, intent(out) :: diagnostic_ids_3d(Atm(tile_count)%idiag_coarse%n_3d_diagnostics)
+  subroutine get_diagnostic_ids_3d(idiag_coarse, diagnostic_ids_3d)
+    type(fv_coarse_diag_type), intent(in) :: idiag_coarse
+    integer, intent(out) :: diagnostic_ids_3d(idiag_coarse%n_3d_diagnostics)
 
-    diagnostic_ids_3d = (/ Atm(tile_count)%idiag_coarse%id_omega_coarse /)
+    diagnostic_ids_3d = (/ idiag_coarse%id_omega_coarse /)
   end subroutine 
   
 end module coarse_grained_diagnostics_mod

--- a/FV3/atmos_cubed_sphere/tools/coarse_graining.F90
+++ b/FV3/atmos_cubed_sphere/tools/coarse_graining.F90
@@ -30,9 +30,8 @@ module coarse_graining_mod
   integer :: coarsening_factor = 8
   integer :: coarse_io_layout(2) = (/1, 1/)
   character(len=64) :: strategy = 'model_level'  ! Valid values are 'model_level'
-  logical :: do_coarse_graining = .false.
   
-  namelist /coarse_graining_nml/ coarsening_factor, coarse_io_layout, strategy, do_coarse_graining
+  namelist /coarse_graining_nml/ coarsening_factor, coarse_io_layout, strategy
 
 contains
 
@@ -49,26 +48,24 @@ contains
 
     read(input_nml_file, coarse_graining_nml, iostat=iostat)
     error_code = check_nml_error(iostat, 'coarse_graining_nml')
-    coarse_graining%do_coarse_graining = do_coarse_graining
+    coarse_graining%do_coarse_graining = .true.
 
-    if (do_coarse_graining) then
-       call assert_valid_strategy(strategy)
-       call compute_nx_coarse(npx, coarsening_factor, nx_coarse)
-       call assert_valid_domain_layout(nx_coarse, layout)
-       call define_cubic_mosaic(coarse_domain, nx_coarse, nx_coarse, layout)
-       call mpp_define_io_domain(coarse_domain, coarse_io_layout)
-       call mpp_get_compute_domain(coarse_domain, is_coarse, ie_coarse, js_coarse, je_coarse)
-       call get_fine_array_bounds(bd, is, ie, js, je)
-       npz = atm_npz
+    call assert_valid_strategy(strategy)
+    call compute_nx_coarse(npx, coarsening_factor, nx_coarse)
+    call assert_valid_domain_layout(nx_coarse, layout)
+    call define_cubic_mosaic(coarse_domain, nx_coarse, nx_coarse, layout)
+    call mpp_define_io_domain(coarse_domain, coarse_io_layout)
+    call mpp_get_compute_domain(coarse_domain, is_coarse, ie_coarse, js_coarse, je_coarse)
+    call get_fine_array_bounds(bd, is, ie, js, je)
+    npz = atm_npz
        
-       coarse_graining%bd%is_coarse = is_coarse
-       coarse_graining%bd%ie_coarse = ie_coarse
-       coarse_graining%bd%js_coarse = js_coarse
-       coarse_graining%bd%je_coarse = je_coarse
-       coarse_graining%nx_coarse = nx_coarse
-       coarse_graining%domain = coarse_domain
-       coarse_graining%strategy = strategy
-    endif    
+    coarse_graining%bd%is_coarse = is_coarse
+    coarse_graining%bd%ie_coarse = ie_coarse
+    coarse_graining%bd%js_coarse = js_coarse
+    coarse_graining%bd%je_coarse = je_coarse
+    coarse_graining%nx_coarse = nx_coarse
+    coarse_graining%domain = coarse_domain
+    coarse_graining%strategy = strategy
   end subroutine coarse_graining_init
 
   subroutine compute_nx_coarse(npx, coarsening_factor, nx_coarse)

--- a/FV3/atmos_cubed_sphere/tools/online_coarse_graining.F90
+++ b/FV3/atmos_cubed_sphere/tools/online_coarse_graining.F90
@@ -30,10 +30,10 @@ module online_coarse_graining_mod
   integer :: coarsening_factor = 8
   integer :: coarse_io_layout(2) = (/1, 1/)
   character(len=64) :: coarse_graining_strategy = 'model_level'
-  logical :: enable_coarse_graining = .false.
+  logical :: do_coarse_graining = .false.
   
   namelist /online_coarse_graining_nml/ coarsening_factor, coarse_io_layout, &
-       coarse_graining_strategy, enable_coarse_graining
+       coarse_graining_strategy, do_coarse_graining
 
 contains
 
@@ -54,9 +54,9 @@ contains
     call close_file(namelist_file)
 #endif
 
-    Atm%coarse_graining_attributes%enable_coarse_graining = enable_coarse_graining
+    Atm%coarse_graining_attrs%do_coarse_graining = do_coarse_graining
 
-    if (enable_coarse_graining) then
+    if (do_coarse_graining) then
        call compute_target_resolution(Atm, coarsening_factor, target_resolution)
        call assert_valid_domain_layout(target_resolution, Atm%layout)
        call define_cubic_mosaic(coarse_domain, target_resolution, target_resolution, Atm%layout)
@@ -65,13 +65,13 @@ contains
        call get_fine_array_bounds(Atm, is, ie, js, je)
        npz = Atm%npz
        
-       Atm%coarse_graining_attributes%coarse_bd%is_coarse = is_coarse
-       Atm%coarse_graining_attributes%coarse_bd%ie_coarse = ie_coarse
-       Atm%coarse_graining_attributes%coarse_bd%js_coarse = js_coarse
-       Atm%coarse_graining_attributes%coarse_bd%je_coarse = je_coarse
-       Atm%coarse_graining_attributes%target_coarse_resolution = target_resolution
-       Atm%coarse_graining_attributes%coarse_domain = coarse_domain
-       Atm%coarse_graining_attributes%coarse_graining_strategy = coarse_graining_strategy
+       Atm%coarse_graining_attrs%bd%is_coarse = is_coarse
+       Atm%coarse_graining_attrs%bd%ie_coarse = ie_coarse
+       Atm%coarse_graining_attrs%bd%js_coarse = js_coarse
+       Atm%coarse_graining_attrs%bd%je_coarse = je_coarse
+       Atm%coarse_graining_attrs%target_resolution = target_resolution
+       Atm%coarse_graining_attrs%domain = coarse_domain
+       Atm%coarse_graining_attrs%strategy = coarse_graining_strategy
     endif    
   end subroutine online_coarse_graining_init
 
@@ -120,10 +120,10 @@ contains
     type(fv_atmos_type), intent(in) :: Atm
     integer, intent(out) :: is_coarse, ie_coarse, js_coarse, je_coarse
 
-    is_coarse = Atm%coarse_graining_attributes%coarse_bd%is_coarse
-    ie_coarse = Atm%coarse_graining_attributes%coarse_bd%ie_coarse
-    js_coarse = Atm%coarse_graining_attributes%coarse_bd%js_coarse
-    je_coarse = Atm%coarse_graining_attributes%coarse_bd%je_coarse
+    is_coarse = Atm%coarse_graining_attrs%bd%is_coarse
+    ie_coarse = Atm%coarse_graining_attrs%bd%ie_coarse
+    js_coarse = Atm%coarse_graining_attrs%bd%js_coarse
+    je_coarse = Atm%coarse_graining_attrs%bd%je_coarse
   end subroutine get_coarse_array_bounds
   
   subroutine block_sum_2d(fine, coarse)

--- a/FV3/atmos_cubed_sphere/tools/online_coarse_graining.F90
+++ b/FV3/atmos_cubed_sphere/tools/online_coarse_graining.F90
@@ -1,0 +1,203 @@
+module online_coarse_graining_mod
+
+  use fv_arrays_mod, only: fv_atmos_type
+  use fms_mod, only: check_nml_error, close_file, open_namelist_file
+  use mpp_domains_mod, only: domain2d, mpp_define_io_domain, mpp_define_mosaic, mpp_get_compute_domain
+  use mpp_mod, only: input_nml_file, mpp_npes
+  
+  implicit none
+  private
+
+  public :: online_coarse_graining_init, weighted_block_average
+
+  interface weighted_block_average
+     module procedure weighted_block_average_2d
+     module procedure weighted_block_average_3d_field_2d_weights
+  end interface weighted_block_average
+  
+  ! Global variables for the module, initialized in online_coarse_graining_init
+  type(domain2d) :: coarse_domain
+  integer :: is, ie, js, je, npz
+  integer :: is_coarse, ie_coarse, js_coarse, je_coarse
+  integer :: target_resolution
+  
+  ! Namelist parameters initialized with default values
+  integer :: coarsening_factor = 8
+  integer :: coarse_io_layout(2) = (/1, 1/)
+  character(len=64) :: coarse_graining_strategy = 'model_level'
+  logical :: write_coarse_grained_restart_files = .false.
+  logical :: write_coarse_grained_diagnostics = .false.
+  
+  namelist /online_coarse_graining_nml/ coarsening_factor, coarse_io_layout, &
+       coarse_graining_strategy, write_coarse_grained_restart_files, &
+       write_coarse_grained_diagnostics
+
+contains
+
+  subroutine online_coarse_graining_init(Atm)
+    type(fv_atmos_type), intent(inout) :: Atm
+
+    character(len=256) :: error_message
+    logical :: exists
+    integer :: namelist_file, error_code, iostat
+
+#ifdef INTERNAL_FILE_NML
+    read(input_nml_file, online_coarse_graining_nml, iostat=iostat)
+    error_code = check_nml_error(iostat, 'online_coarse_graining_nml')
+#else
+    namelist_file = open_namelist_file(Atm%nml_filename)
+    read(namelist_file, online_coarse_graining_nml, iostat=iostat)
+    error_code = check_nml_error(iostat, 'online_coarse_graining_nml')
+    call close_file(namelist_file)
+#endif
+
+    npz = Atm%npz
+    call compute_target_resolution(Atm, coarsening_factor, target_resolution)
+    call define_cubic_mosaic(coarse_domain, target_resolution, target_resolution, Atm%layout)
+    call mpp_define_io_domain(coarse_domain, coarse_io_layout)
+    call mpp_get_compute_domain(coarse_domain, is_coarse, ie_coarse, js_coarse, je_coarse)
+
+    Atm%coarse_bd%is_coarse = is_coarse
+    Atm%coarse_bd%ie_coarse = ie_coarse
+    Atm%coarse_bd%js_coarse = js_coarse
+    Atm%coarse_bd%je_coarse = je_coarse
+
+    Atm%target_coarse_resolution = target_resolution
+    Atm%coarse_domain = coarse_domain
+  end subroutine online_coarse_graining_init
+
+  subroutine compute_target_resolution(Atm, coarsening_factor, target_resolution)
+    type(fv_atmos_type), intent(in) :: Atm
+    integer, intent(in) :: coarsening_factor
+    integer, intent(out) :: target_resolution
+    integer :: native_resolution
+    native_resolution = Atm%flagstruct%npx - 1
+    target_resolution = native_resolution / coarsening_factor
+  end subroutine compute_target_resolution
+  
+  ! This subroutine is copied from fms/horiz_interp/horiz_interp_test.F90;
+  ! domain_decomp in fv_mp_mod.F90 does something similar, but it does a
+  ! few other unnecessary things (and requires more arguments).
+  subroutine define_cubic_mosaic(domain, ni, nj, layout)
+    type(domain2d), intent(inout) :: domain
+    integer,        intent(in)    :: layout(:)
+    integer,        intent(in)    :: ni, nj
+    integer   :: pe_start(6), pe_end(6)
+    integer   :: global_indices(4,6), layout2d(2,6)
+    integer, dimension(12)        :: istart1, iend1, jstart1, jend1, tile1
+    integer, dimension(12)        :: istart2, iend2, jstart2, jend2, tile2
+    integer                       :: ntiles, num_contact
+    integer :: p, npes_per_tile, i
+
+    ntiles = 6
+    num_contact = 12
+    p = 0
+    npes_per_tile = mpp_npes()/ntiles
+    do i = 1, 6
+       layout2d(:,i) = layout(:)
+       global_indices(1,i) = 1
+       global_indices(2,i) = ni
+       global_indices(3,i) = 1
+       global_indices(4,i) = nj
+       pe_start(i) = p
+       p = p + npes_per_tile
+       pe_end(i) = p-1
+    enddo
+
+    !--- Contact line 1, between tile 1 (EAST) and tile 2 (WEST)
+    tile1(1) = 1;     tile2(1) = 2
+    istart1(1) = ni;  iend1(1) = ni;  jstart1(1) = 1;      jend1(1) = nj
+    istart2(1) = 1;   iend2(1) = 1;   jstart2(1) = 1;      jend2(1) = nj
+
+    !--- Contact line 2, between tile 1 (NORTH) and tile 3 (WEST)
+    tile1(2) = 1; tile2(2) = 3
+    istart1(2) = 1;      iend1(2) = ni;  jstart1(2) = nj;  jend1(2) = nj
+    istart2(2) = 1;      iend2(2) = 1;   jstart2(2) = nj;  jend2(2) = 1
+
+    !--- Contact line 3, between tile 1 (WEST) and tile 5 (NORTH)
+    tile1(3) = 1;     tile2(3) = 5
+    istart1(3) = 1;   iend1(3) = 1;      jstart1(3) = 1;   jend1(3) = nj
+    istart2(3) = ni;  iend2(3) = 1;      jstart2(3) = nj;  jend2(3) = nj
+
+    !--- Contact line 4, between tile 1 (SOUTH) and tile 6 (NORTH)
+    tile1(4) = 1; tile2(4) = 6
+    istart1(4) = 1;      iend1(4) = ni;  jstart1(4) = 1;   jend1(4) = 1
+    istart2(4) = 1;      iend2(4) = ni;  jstart2(4) = nj;  jend2(4) = nj
+
+    !--- Contact line 5, between tile 2 (NORTH) and tile 3 (SOUTH)
+    tile1(5) = 2;        tile2(5) = 3
+    istart1(5) = 1;      iend1(5) = ni;  jstart1(5) = nj;  jend1(5) = nj
+    istart2(5) = 1;      iend2(5) = ni;  jstart2(5) = 1;   jend2(5) = 1
+
+    !--- Contact line 6, between tile 2 (EAST) and tile 4 (SOUTH)
+    tile1(6) = 2; tile2(6) = 4
+    istart1(6) = ni;  iend1(6) = ni;  jstart1(6) = 1;      jend1(6) = nj
+    istart2(6) = ni;  iend2(6) = 1;   jstart2(6) = 1;      jend2(6) = 1
+
+    !--- Contact line 7, between tile 2 (SOUTH) and tile 6 (EAST)
+    tile1(7) = 2; tile2(7) = 6
+    istart1(7) = 1;   iend1(7) = ni;  jstart1(7) = 1;   jend1(7) = 1
+    istart2(7) = ni;  iend2(7) = ni;  jstart2(7) = nj;  jend2(7) = 1
+
+    !--- Contact line 8, between tile 3 (EAST) and tile 4 (WEST)
+    tile1(8) = 3; tile2(8) = 4
+    istart1(8) = ni;  iend1(8) = ni;  jstart1(8) = 1;      jend1(8) = nj
+    istart2(8) = 1;   iend2(8) = 1;   jstart2(8) = 1;      jend2(8) = nj
+
+    !--- Contact line 9, between tile 3 (NORTH) and tile 5 (WEST)
+    tile1(9) = 3; tile2(9) = 5
+    istart1(9) = 1;      iend1(9) = ni;  jstart1(9) = nj;  jend1(9) = nj
+    istart2(9) = 1;      iend2(9) = 1;   jstart2(9) = nj;  jend2(9) = 1
+
+    !--- Contact line 10, between tile 4 (NORTH) and tile 5 (SOUTH)
+    tile1(10) = 4; tile2(10) = 5
+    istart1(10) = 1;     iend1(10) = ni; jstart1(10) = nj; jend1(10) = nj
+    istart2(10) = 1;     iend2(10) = ni; jstart2(10) = 1;  jend2(10) = 1
+
+    !--- Contact line 11, between tile 4 (EAST) and tile 6 (SOUTH)
+    tile1(11) = 4; tile2(11) = 6
+    istart1(11) = ni; iend1(11) = ni; jstart1(11) = 1;     jend1(11) = nj
+    istart2(11) = ni; iend2(11) = 1;  jstart2(11) = 1;     jend2(11) = 1
+
+    !--- Contact line 12, between tile 5 (EAST) and tile 6 (WEST)
+    tile1(12) = 5; tile2(12) = 6
+    istart1(12) = ni; iend1(12) = ni; jstart1(12) = 1;     jend1(12) = nj
+    istart2(12) = 1;  iend2(12) = 1;  jstart2(12) = 1;     jend2(12) = nj
+
+    call mpp_define_mosaic(global_indices, layout2d, domain, ntiles, &
+         num_contact, tile1, tile2, istart1, iend1, jstart1, jend1, &
+         istart2, iend2, jstart2, jend2, pe_start, pe_end, &
+         symmetry=.true., name='coarse cubic mosaic')
+
+    return    
+  end subroutine define_cubic_mosaic
+
+  subroutine weighted_block_average_2d(weights, fine, coarse)
+    real, intent(in) :: weights(is:ie,js:je), fine(is:ie,js:je)
+    real, intent(out) :: coarse(is_coarse:ie_coarse,js_coarse:je_coarse)
+
+    real, allocatable :: weighted_fine(:,:)
+    integer :: i, j, i_coarse, j_coarse, offset
+
+    offset = coarsening_factor - 1
+    do i = is, ie, coarsening_factor
+       i_coarse = (i - 1) / coarsening_factor + 1
+       do j = js, je, coarsening_factor
+          j_coarse = (j - 1) / coarsening_factor + 1
+          coarse(i_coarse,j_coarse) = sum(weighted_fine(i:i+offset,j:j+offset)) / sum(weights(i:i+offset,j:j+offset))
+       enddo
+    enddo
+  end subroutine weighted_block_average_2d
+
+  subroutine weighted_block_average_3d_field_2d_weights(weights, fine, coarse)
+    real, intent(in) :: weights(is:ie,js:je), fine(is:ie,js:je,1:npz)
+    real, intent(out) :: coarse(is_coarse:ie_coarse,js_coarse:je_coarse,1:npz)
+
+    integer :: k
+
+    do k = 1, npz
+       call weighted_block_average_2d(weights, fine(is:ie,js:je,k), coarse(is_coarse:ie_coarse,js_coarse:je_coarse,k))
+    enddo
+  end subroutine weighted_block_average_3d_field_2d_weights
+  
+end module online_coarse_graining_mod

--- a/FV3/atmos_cubed_sphere/tools/online_coarse_graining.F90
+++ b/FV3/atmos_cubed_sphere/tools/online_coarse_graining.F90
@@ -12,7 +12,6 @@ module online_coarse_graining_mod
 
   interface block_sum
      module procedure block_sum_2d
-     module procedure block_sum_3d
   end interface block_sum
   
   interface weighted_block_average

--- a/FV3/atmos_cubed_sphere/tools/online_coarse_graining.F90
+++ b/FV3/atmos_cubed_sphere/tools/online_coarse_graining.F90
@@ -30,12 +30,10 @@ module online_coarse_graining_mod
   integer :: coarsening_factor = 8
   integer :: coarse_io_layout(2) = (/1, 1/)
   character(len=64) :: coarse_graining_strategy = 'model_level'
-  logical :: write_coarse_grained_restart_files = .false.
-  logical :: write_coarse_grained_diagnostics = .false.
+  logical :: enable_coarse_graining = .false.
   
   namelist /online_coarse_graining_nml/ coarsening_factor, coarse_io_layout, &
-       coarse_graining_strategy, write_coarse_grained_restart_files, &
-       write_coarse_grained_diagnostics
+       coarse_graining_strategy, enable_coarse_graining
 
 contains
 
@@ -56,10 +54,9 @@ contains
     call close_file(namelist_file)
 #endif
 
-    Atm%coarse_graining_attributes%write_coarse_grained_restart_files = write_coarse_grained_restart_files
-    Atm%coarse_graining_attributes%write_coarse_grained_diagnostics = write_coarse_grained_diagnostics
+    Atm%coarse_graining_attributes%enable_coarse_graining = enable_coarse_graining
 
-    if (write_coarse_grained_restart_files .or. write_coarse_grained_diagnostics) then
+    if (enable_coarse_graining) then
        call compute_target_resolution(Atm, coarsening_factor, target_resolution)
        call assert_valid_domain_layout(target_resolution, Atm%layout)
        call define_cubic_mosaic(coarse_domain, target_resolution, target_resolution, Atm%layout)

--- a/FV3/atmos_cubed_sphere/tools/online_coarse_graining.F90
+++ b/FV3/atmos_cubed_sphere/tools/online_coarse_graining.F90
@@ -145,17 +145,6 @@ contains
        enddo
     enddo
   end subroutine
-
-  subroutine block_sum_3d(fine, coarse)
-    real, intent(in) :: fine(is:ie,js:je,1:npz)
-    real, intent(out) :: coarse(is_coarse:ie_coarse,js_coarse:je_coarse,1:npz)
-
-    integer :: k
-
-    do k = 1, npz
-       call block_sum_2d(fine(is:ie,js:je,k), coarse(is_coarse:ie_coarse,js_coarse:je_coarse,k))
-    enddo
-  end subroutine block_sum_3d
   
   subroutine weighted_block_average_2d(weights, fine, coarse)
     real, intent(in) :: weights(is:ie,js:je), fine(is:ie,js:je)


### PR DESCRIPTION
This PR provides a slightly cleaned up sketch of how I've implemented online coarse-graining in SHiELD.  To keep the diff somewhat light, I've only added a single coarse diagnostic, `omega_coarse`, with the only strategy option being model-level coarse-graining.  It would be great to get some initial feedback on this work before I proceed any further.

So currently the way one would use this new functionality would be that they would need to activate coarse-graining in the namelist by providing a `coarsening_factor`, and setting the `do_coarse_graining` flag to `.true.`:
```
&fv_core_nml
    ...
    do_coarse_graining = .true.
/

&online_coarse_graining_nml
    coarsening_factor = 2
/
```
This is where the `strategy` would be specified, if multiple were implemented.  One can also set a separate I/O layout for coarse restart files and diagnostics; by default this is set to `(1, 1)` for ease of post-processing.  If coarse-graining is active, the `omega_coarse` diagnostic will be registered, and available to output.

One aspect I'll note about the implementation is that I've defined a number of module-level variables in `coarse_graining.F90` to keep things less verbose when calling coarse-graining subroutines (i.e. you don't need to provide the coarsening factor or fine/coarse explicit array bounds when calling the routines); however a limitation of this is that it makes it harder (if we ever wanted to) adapt the code to coarse-grain online to multiple resolutions.  Open to suggestions on that or anything else!

Once we merge this I'll submit more PRs so we can work through porting all the functionality needed for a 3 km simulation (coarse-graining more dynamical core diagnostics, coarse-graining physics diagnostics, coarse-graining dynamical core and physics restart files, pressure level coarse-graining, surface field coarse-graining, eddy flux diagnostics etc.), hopefully in manageable chunks.