### PR TITLE
Set surface precip to zero on init when using dycore_only=True

### DIFF
--- a/FV3/atmos_model.F90
+++ b/FV3/atmos_model.F90
@@ -685,6 +685,12 @@ subroutine atmos_model_init (Atmos, Time_init, Time, Time_step)
    call FV3GFS_restart_read (IPD_Data, IPD_Restart, Atm_block, IPD_Control, Atmos%domain)
 #endif
 
+   if (dycore_only) then
+     do nb = 1, Atm_block%nblks
+       IPD_Data(nb)%Sfcprop%tprcp(:) = 0.0
+     end do
+   endif
+
    !--- set the initial diagnostic timestamp
    diag_time = Time 
    if (output_1st_tstep_rst) then

--- a/FV3/atmos_model.F90
+++ b/FV3/atmos_model.F90
@@ -457,7 +457,7 @@ subroutine atmos_model_init (Atmos, Time_init, Time, Time_step)
   integer              :: bdat(8), cdat(8)
   integer              :: ntracers, maxhf, maxh
   character(len=32), allocatable, target :: tracer_names(:)
-  integer :: nthrds
+  integer :: nthrds, nb
 
 !-----------------------------------------------------------------------
 


### PR DESCRIPTION
This PR sets the total surface precipitation variable to zero during model initialization if `dycore_only=True`. Otherwise, since the physics routines are never called when using `dycore_only=True`, this variable remains equal to whatever value it has in the initial condition.