### PR TITLE
Feature/restart write disable

### DIFF
--- a/FMS/affinity/affinity.c
+++ b/FMS/affinity/affinity.c
@@ -27,6 +27,12 @@
 #include <sys/resource.h>
 #include <sys/syscall.h>
 
+static pid_t gettid1(void)
+{
+#ifndef __APPLE__
+  return syscall(SYS_gettid);
+#endif
+}
 
 /*
  * Returns this thread's CPU affinity, if bound to a single core,
@@ -38,8 +44,8 @@ int get_cpu_affinity(void)
   cpu_set_t coremask;           /* core affinity mask */
 
   CPU_ZERO(&coremask);
-  if (sched_getaffinity(gettid(),sizeof(cpu_set_t),&coremask) != 0) {
-    fprintf(stderr,"Unable to get thread %d affinity. %s\n",gettid(),strerror(errno));
+  if (sched_getaffinity(gettid1(),sizeof(cpu_set_t),&coremask) != 0) {
+    fprintf(stderr,"Unable to get thread %d affinity. %s\n",gettid1(),strerror(errno));
   }
 
   int cpu;
@@ -65,8 +71,8 @@ int get_cpuset(int fsz, int *output, int pe, _Bool debug)
   cpu_set_t coremask; /* core affinity mask */
 
   CPU_ZERO(&coremask);
-  if (sched_getaffinity(gettid(),sizeof(cpu_set_t),&coremask) != 0) {
-    fprintf(stderr,"Unable to get thread %d affinity. %s\n",gettid(),strerror(errno));
+  if (sched_getaffinity(gettid1(),sizeof(cpu_set_t),&coremask) != 0) {
+    fprintf(stderr,"Unable to get thread %d affinity. %s\n",gettid1(),strerror(errno));
   }
 
   int  cpu;
@@ -109,7 +115,7 @@ int set_cpu_affinity(int cpu)
 
   CPU_ZERO(&coremask);
   CPU_SET(cpu,&coremask);
-  if (sched_setaffinity(gettid(),sizeof(cpu_set_t),&coremask) != 0) {
+  if (sched_setaffinity(gettid1(),sizeof(cpu_set_t),&coremask) != 0) {
     return -1;
   }
 #endif

--- a/FV3/atmos_cubed_sphere/driver/fvGFS/atmosphere.F90
+++ b/FV3/atmos_cubed_sphere/driver/fvGFS/atmosphere.F90
@@ -832,7 +832,7 @@ contains
   subroutine atmosphere_restart(timestamp)
     character(len=*),  intent(in) :: timestamp
 
-    call fv_write_restart(Atm, grids_on_this_pe, timestamp)
+    if (.not. Atm(mytile)%flagstruct%disable_fv_restart_write) call fv_write_restart(Atm, grids_on_this_pe, timestamp)
 
   end subroutine atmosphere_restart
  

--- a/FV3/atmos_cubed_sphere/model/fv_arrays.F90
+++ b/FV3/atmos_cubed_sphere/model/fv_arrays.F90
@@ -835,6 +835,8 @@ module fv_arrays_mod
  
    logical :: fv_debug = .false.   !< Whether to turn on additional diagnostics in fv_dynamics. 
                                    !< The default is .false.
+   logical :: disable_fv_restart_write = .false.   !< Whether to disable saving fv_* restart files during a run.
+                                                   !< The default is .false.
    logical :: srf_init = .false.
    logical :: mountain = .true.   !< Takes topography into account when initializing the
                                   !< model. Set this to .true. to apply the terrain filter (if n_zs_filter = 2

--- a/FV3/atmos_cubed_sphere/model/fv_control.F90
+++ b/FV3/atmos_cubed_sphere/model/fv_control.F90
@@ -284,7 +284,8 @@ module fv_control_mod
    logical , pointer :: reed_cond_only
    logical , pointer :: reproduce_sum 
    logical , pointer :: adjust_dry_mass 
-   logical , pointer :: fv_debug  
+   logical , pointer :: fv_debug 
+   logical , pointer :: disable_fv_restart_write 
    logical , pointer :: srf_init  
    logical , pointer :: mountain  
    logical , pointer :: remap_t  
@@ -609,8 +610,7 @@ module fv_control_mod
 
     call timing_off('TOTAL')
     call timing_prt( gid )
-
-    call fv_restart_end(Atm, grids_on_this_pe)
+    if (.NOT. disable_fv_restart_write) call fv_restart_end(Atm, grids_on_this_pe)
     call fv_io_exit()
 
   ! Free temporary memory from sw_core routines
@@ -661,7 +661,7 @@ module fv_control_mod
    namelist /fv_core_nml/npx, npy, ntiles, npz, npz_rst, layout, io_layout, ncnst, nwat,  &
                          use_logp, p_fac, a_imp, k_split, n_split, m_split, q_split, print_freq, write_3d_diags, do_schmidt,  &
                          hord_mt, hord_vt, hord_tm, hord_dp, hord_tr, shift_fac, stretch_fac, target_lat, target_lon, &
-                         kord_mt, kord_wz, kord_tm, kord_tr, fv_debug, fv_land, nudge, do_sat_adj, do_f3d, &
+                         kord_mt, kord_wz, kord_tm, kord_tr, fv_debug, disable_fv_restart_write, fv_land, nudge, do_sat_adj, do_f3d, &
                          external_ic, read_increment, ncep_ic, nggps_ic, ecmwf_ic, use_new_ncep, use_ncep_phy, fv_diag_ic, &
                          external_eta, res_latlon_dynamics, res_latlon_tracers, scale_z, w_max, z_min, lim_fac, &
                          dddmp, d2_bg, d4_bg, vtdm4, trdm2, d_ext, delt_max, beta, non_ortho, n_sponge, &
@@ -1298,6 +1298,7 @@ module fv_control_mod
      reproduce_sum                 => Atm%flagstruct%reproduce_sum
      adjust_dry_mass               => Atm%flagstruct%adjust_dry_mass
      fv_debug                      => Atm%flagstruct%fv_debug
+     disable_fv_restart_write      => Atm%flagstruct%disable_fv_restart_write
      srf_init                      => Atm%flagstruct%srf_init
      mountain                      => Atm%flagstruct%mountain
      remap_t                       => Atm%flagstruct%remap_t

--- a/FV3/atmos_model.F90
+++ b/FV3/atmos_model.F90
@@ -168,15 +168,15 @@ integer :: blocksize    = 1
 logical :: chksum_debug = .false.
 logical :: dycore_only  = .false.
 logical :: debug        = .false.
-!logical :: debug        = .true.
 logical :: sync         = .false.
+logical :: disable_phys_restart_write = .false.
 integer, parameter     :: maxhr = 65536
 real, dimension(maxhr) :: fdiag = 0.
 real                   :: fhmax=384.0, fhmaxhf=120.0, fhout=3.0, fhouthf=1.0,avg_max_length=3600.
 #ifdef CCPP
-namelist /atmos_model_nml/ blocksize, chksum_debug, dycore_only, debug, sync, fdiag, fhmax, fhmaxhf, fhout, fhouthf, ccpp_suite, avg_max_length
+namelist /atmos_model_nml/ blocksize, chksum_debug, dycore_only, debug, sync, fdiag, fhmax, fhmaxhf, fhout, fhouthf, disable_phys_restart_write, ccpp_suite, avg_max_length
 #else
-namelist /atmos_model_nml/ blocksize, chksum_debug, dycore_only, debug, sync, fdiag, fhmax, fhmaxhf, fhout, fhouthf, avg_max_length
+namelist /atmos_model_nml/ blocksize, chksum_debug, dycore_only, debug, sync, fdiag, fhmax, fhmaxhf, fhout, fhouthf, disable_phys_restart_write, avg_max_length
 #endif
 
 type (time_type) :: diag_time, diag_time_fhzero
@@ -957,8 +957,10 @@ subroutine atmos_model_end (Atmos)
 !---- termination routine for atmospheric model ----
                                               
     call atmosphere_end (Atmos % Time, Atmos%grid)
-    call FV3GFS_restart_write (IPD_Data, IPD_Restart, Atm_block, &
-                               IPD_Control, Atmos%domain)
+    if (.not. disable_phys_restart_write) then
+       call FV3GFS_restart_write (IPD_Data, IPD_Restart, Atm_block, &
+                                  IPD_Control, Atmos%domain)
+    endif
 
 #ifdef CCPP
 !   Fast physics (from dynamics) are finalized in atmosphere_end above;
@@ -981,8 +983,10 @@ subroutine atmos_model_restart(Atmos, timestamp)
   character(len=*),  intent(in)           :: timestamp
 
     call atmosphere_restart(timestamp)
-    call FV3GFS_restart_write (IPD_Data, IPD_Restart, Atm_block, &
-                               IPD_Control, Atmos%domain, timestamp)
+    if (.not. disable_phys_restart_write) then
+       call FV3GFS_restart_write (IPD_Data, IPD_Restart, Atm_block, &
+                                  IPD_Control, Atmos%domain, timestamp)
+    endif
 
 end subroutine atmos_model_restart
 ! </SUBROUTINE>

--- a/FV3/conf/configure.fv3.piz_daint_intel
+++ b/FV3/conf/configure.fv3.piz_daint_intel
@@ -1,0 +1,118 @@
+## configure.fv3.piz_daint_intel
+##
+## This configure file outlines support for the creation of an Intel compiler build of FV3
+## on the Swiss supercomputer, Piz Daint (a Cray XC-50).  OpenMP and vector (AVX2) support
+## is enabled.  A 64-bit compilation is performed of all the dynamics and physics modules
+##
+##  Mark Cheeseman, Vulcan Inc
+##  July 2, 2020
+##==========================================================================================
+
+# compiler commands 
+FC = ftn
+CC = cc
+LD = $(FC) -cxxlib
+
+# fv3 compile options 
+DEBUG =
+REPRO =
+VERBOSE =
+OPENMP = Y
+AVX2 = Y
+HYDRO = N
+
+NEMSIOINC = -I$(NCEPLIBS_DIR)/include
+NCEPLIBS = -L$(NCEPLIBS_DIR)/lib -lbacio_4 -lsp_v2.0.2_d -lw3nco_d
+
+##############################################
+# Need to use at least GNU Make version 3.81 #
+##############################################
+need := 3.81
+ok := $(filter $(need),$(firstword $(sort $(MAKE_VERSION) $(need))))
+ifneq ($(need),$(ok))
+$(error Need at least make version $(need))
+endif
+
+MKL_DIR=${MKLROOT}
+INCLUDE = -I${NETCDF_ROOT}/include -I${ESMF_DIR}/include -I$(MKL_DIR)/include -I$(MKL_DIR)/include/intel64/ilp64 -I${FMS_DIR}/include
+
+FPPFLAGS := -cpp -Wp,-w $(INCLUDE)
+CFLAGS := $(INCLUDE) -qno-opt-dynamic-align
+
+FFLAGS := $(INCLUDE) -fno-alias -auto -safe-cray-ptr -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -qno-opt-dynamic-align
+CPPDEFS += -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO -Duse_LARGEFILE -DUSE_GFSL63 -DGFS_PHYS
+CPPDEFS += -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DNO_INLINE_POST -D__GFORTRAN__ -DDISABLE_ESMF_DGEMM
+
+ifneq ($(HYDRO),Y)
+CPPDEFS += -DMOIST_CAPPA -DUSE_COND
+endif
+
+ifeq ($(32BIT),Y)
+CPPDEFS += -DOVERLOAD_R4 -DOVERLOAD_R8
+FFLAGS += -real-size 32
+else
+FFLAGS += -real-size 64 -no-prec-div -no-prec-sqrt
+endif
+
+ifeq ($(AVX2),Y)
+FFLAGS += -xCORE-AVX2
+CFLAGS += -xCORE-AVX2
+else
+FFLAGS += -xHOST
+CFLAGS += -xHOST
+endif
+
+FFLAGS_OPT = -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3
+FFLAGS_REPRO = -O2 -debug minimal -fp-model source -qoverride-limits -g -traceback
+FFLAGS_DEBUG = -g -O0 -check -check noarg_temp_created -check nopointer -warn -warn noerrors -fp-stack-check -fstack-protector-all -fpe0 -debug -traceback -ftrapuv
+
+FFLAGS_OPENMP = -qopenmp
+FFLAGS_VERBOSE = -v -V -what
+
+CFLAGS += -D__IFC -sox -fp-model source
+
+CFLAGS_OPT = -O2 -debug minimal
+CFLAGS_REPRO = -O2 -debug minimal
+CFLAGS_OPENMP = -qopenmp
+CFLAGS_DEBUG = -O0 -g -ftrapuv -traceback
+
+LDFLAGS :=
+LDFLAGS_OPENMP := -qopenmp
+LDFLAGS_VERBOSE := -Wl,-V,--verbose,-cref,-M
+
+# start with blank LIBS
+LIBS := -L/opt/intel/compilers_and_libraries_2019.1.144/linux/compiler/lib -lifcoremt
+
+FAST :=
+ifneq ($(REPRO),)
+CFLAGS += $(CFLAGS_REPRO)
+FFLAGS += $(FFLAGS_REPRO)
+else ifneq ($(DEBUG),)
+CFLAGS += $(CFLAGS_DEBUG)
+FFLAGS += $(FFLAGS_DEBUG)
+else ifneq ($(TEST),)
+CFLAGS += $(CFLAGS_TEST)
+FFLAGS += $(FFLAGS_TEST)
+else
+CFLAGS += $(CFLAGS_OPT)
+FFLAGS += $(FFLAGS_OPT)
+endif
+
+ifneq ($(OPENMP),)
+CFLAGS += $(CFLAGS_OPENMP)
+FFLAGS += $(FFLAGS_OPENMP)
+LDFLAGS += $(LDFLAGS_OPENMP)
+endif
+
+ifneq ($(VERBOSE),)
+CFLAGS += $(CFLAGS_VERBOSE)
+FFLAGS += $(FFLAGS_VERBOSE)
+LDFLAGS += $(LDFLAGS_VERBOSE)
+endif
+
+LIBS += -L${ESMF_DIR}/lib -lesmf -L${FMS_DIR}/lib -lFMS -L${NETCDF_ROOT}/lib -lnetcdff -lnetcdf
+
+# Intel MKL library support
+LIBS += -L$(MKL_DIR)/lib/intel64 -Wl,--start-group $(MKL_DIR)/lib/intel64/libmkl_intel_lp64.a $(MKL_DIR)/lib/intel64/libmkl_intel_thread.a $(MKL_DIR)/lib/intel64/libmkl_core.a -Wl,--end-group -liomp5 -lpthread -lm
+
+LDFLAGS += $(LIBS)

--- a/FV3/testsuite/data/c48_basic/test_baseline/input.nml
+++ b/FV3/testsuite/data/c48_basic/test_baseline/input.nml
@@ -11,6 +11,7 @@
  blocksize = 24
  chksum_debug = .false.
  dycore_only = .F.
+ disable_phys_restart_write = .F.
  fdiag = 1.
 /
 
@@ -42,6 +43,7 @@
  npz    = 63
  make_nh = .T.
  fv_debug = .F.
+ disable_fv_restart_write = .F.
  fv_testsuite_output = .T.
  perturbation_type = 0
  range_warn = .T.


### PR DESCRIPTION
Contains the following:
1) fix to the undefined gettid_ symbol error when linking the FV3 binary on Piz Daint
2) added FV3 configure script for Intel compiler support on Piz Daint
3) added namelist options to disable the writing of the physics and dynamics restart files