### PR TITLE
Add coarse graining to clean make directive

### DIFF
--- a/FV3/makefile
+++ b/FV3/makefile
@@ -203,6 +203,7 @@ clean_no_dycore:
 	(cd ../stochastic_physics && make clean)
 	(cd io                    && make clean)
 	(cd cpl                   && make clean)
+	(cd coarse_graining       && make clean)
 	$(RM) -f $(FV3_EXE) $(FV3CAP_LIB) *.o *.mod *.i90 *.lst depend
 
 cleanall: clean

--- a/FV3/makefile
+++ b/FV3/makefile
@@ -191,6 +191,7 @@ clean:
 	(cd io                    && make clean)
 	(cd atmos_cubed_sphere    && make clean)
 	(cd cpl                   && make clean)
+	(cd coarse_graining       && make clean)
 	$(RM) -f $(FV3_EXE) $(FV3CAP_LIB) *.o *.mod *.i90 *.lst depend
 
 clean_no_dycore:


### PR DESCRIPTION
Currently the coarse graining `depend` files are left over when running `make clean`. This adds `coarse_graining` to the `clean` directive in `FV3`.