### PR TITLE
[VCMML-448] Add per-physics component temperature and water vapor tendency diagnostics

### DIFF
--- a/FV3/atmos_cubed_sphere/driver/fvGFS/atmosphere.F90
+++ b/FV3/atmos_cubed_sphere/driver/fvGFS/atmosphere.F90
@@ -188,7 +188,6 @@ use fv_sg_mod,          only: fv_subgrid_z
 use fv_update_phys_mod, only: fv_update_phys
 use fv_nwp_nudge_mod,   only: fv_nwp_nudge_init, fv_nwp_nudge_end, do_adiabatic_init
 use fv_io_mod,          only: fv_io_register_nudge_restart
-use fv_mapz_mod,        only: moist_cv
 #ifdef MULTI_GASES
 use multi_gases_mod,  only: virq, virq_max, num_gas, ri, cpi
 #endif
@@ -2180,6 +2179,7 @@ contains
         enddo
     endif
     IPD_Data(nb)%Statein%dycore_hydrostatic = Atm(mytile)%flagstruct%hydrostatic
+    IPD_Data(nb)%Statein%nwat = Atm(mytile)%flagstruct%nwat
   enddo
 
  end subroutine atmos_phys_driver_statein

--- a/FV3/atmos_cubed_sphere/driver/fvGFS/atmosphere.F90
+++ b/FV3/atmos_cubed_sphere/driver/fvGFS/atmosphere.F90
@@ -188,6 +188,7 @@ use fv_sg_mod,          only: fv_subgrid_z
 use fv_update_phys_mod, only: fv_update_phys
 use fv_nwp_nudge_mod,   only: fv_nwp_nudge_init, fv_nwp_nudge_end, do_adiabatic_init
 use fv_io_mod,          only: fv_io_register_nudge_restart
+use fv_mapz_mod,        only: moist_cv
 #ifdef MULTI_GASES
 use multi_gases_mod,  only: virq, virq_max, num_gas, ri, cpi
 #endif

--- a/FV3/atmos_cubed_sphere/driver/fvGFS/atmosphere.F90
+++ b/FV3/atmos_cubed_sphere/driver/fvGFS/atmosphere.F90
@@ -173,7 +173,7 @@ use fv_iau_mod,             only: IAU_external_data_type
 !-----------------
 ! FV core modules:
 !-----------------
-use fv_arrays_mod,      only: fv_atmos_type, R_GRID
+use fv_arrays_mod,      only: fv_atmos_type, phys_diag_type, R_GRID
 use fv_control_mod,     only: fv_init, fv_end, ngrids
 use fv_eta_mod,         only: get_eta_level
 use fv_fill_mod,        only: fill_gfs
@@ -1533,6 +1533,9 @@ contains
    call set_domain ( Atm(mytile)%domain )
 
    call timing_on('GFS_TENDENCIES')
+
+   call atmos_phys_qdt_diag(Atm(n)%q, Atm(n)%phys_diag, nt_dyn, dt_atmos, .true.)
+
 !--- put u/v tendencies into haloed arrays u_dt and v_dt
 !$OMP parallel do default (none) & 
 !$OMP              shared (rdt, n, nq, dnats, npz, ncnst, nwat, mytile, u_dt, v_dt, t_dt,&
@@ -1611,6 +1614,8 @@ contains
 
    enddo  ! nb-loop
 
+   call atmos_phys_qdt_diag(Atm(n)%q, Atm(n)%phys_diag, nt_dyn, dt_atmos, .false.)
+
    call timing_off('GFS_TENDENCIES')
 
    w_diff = get_tracer_index (MODEL_ATMOS, 'w_diff' )
@@ -1653,7 +1658,7 @@ contains
                          Atm(n)%gridstruct%agrid(:,:,1), Atm(n)%gridstruct%agrid(:,:,2),   &
                          Atm(n)%npx, Atm(n)%npy, Atm(n)%npz, Atm(n)%flagstruct,            &
                          Atm(n)%neststruct, Atm(n)%bd, Atm(n)%domain, Atm(n)%ptop,         &
-                         Atm(n)%nudge_diag)
+                         Atm(n)%nudge_diag, Atm(n)%phys_diag)
        call timing_off('FV_UPDATE_PHYS')
    call mpp_clock_end (id_dynam)
 
@@ -2176,5 +2181,23 @@ contains
   enddo
 
  end subroutine atmos_phys_driver_statein
+
+ subroutine atmos_phys_qdt_diag(q, phys_diag, nq, dt, begin)
+   integer, intent(in) :: nq
+   real, intent(in) :: q(isd:ied,jsd:jed,1:npz,1:nq)
+   real, intent(in) :: dt
+   logical, intent(in) :: begin
+   type(phys_diag_type), intent(inout) :: phys_diag
+
+   integer :: sphum
+
+   sphum = get_tracer_index (MODEL_ATMOS, 'sphum')
+
+   if (begin) then
+      if (allocated(phys_diag%qv_dt)) phys_diag%qv_dt = q(isc:iec,jsc:jec,1:npz,sphum)
+   else
+      if (allocated(phys_diag%qv_dt)) phys_diag%qv_dt = (q(isc:iec,jsc:jec,1:npz,sphum) - phys_diag%qv_dt) / dt
+   endif
+ end subroutine atmos_phys_qdt_diag
 
 end module atmosphere_mod

--- a/FV3/atmos_cubed_sphere/driver/fvGFS/atmosphere.F90
+++ b/FV3/atmos_cubed_sphere/driver/fvGFS/atmosphere.F90
@@ -173,7 +173,7 @@ use fv_iau_mod,             only: IAU_external_data_type
 !-----------------
 ! FV core modules:
 !-----------------
-use fv_arrays_mod,      only: fv_atmos_type, phys_diag_type, R_GRID
+use fv_arrays_mod,      only: fv_atmos_type, physics_tendency_diag_type, R_GRID
 use fv_control_mod,     only: fv_init, fv_end, ngrids
 use fv_eta_mod,         only: get_eta_level
 use fv_fill_mod,        only: fill_gfs
@@ -1535,7 +1535,7 @@ contains
 
    call timing_on('GFS_TENDENCIES')
 
-   call atmos_phys_qdt_diag(Atm(n)%q, Atm(n)%phys_diag, nt_dyn, dt_atmos, .true.)
+   call atmos_phys_qdt_diag(Atm(n)%q, Atm(n)%physics_tendency_diag, nt_dyn, dt_atmos, .true.)
 
 !--- put u/v tendencies into haloed arrays u_dt and v_dt
 !$OMP parallel do default (none) & 
@@ -1615,7 +1615,7 @@ contains
 
    enddo  ! nb-loop
 
-   call atmos_phys_qdt_diag(Atm(n)%q, Atm(n)%phys_diag, nt_dyn, dt_atmos, .false.)
+   call atmos_phys_qdt_diag(Atm(n)%q, Atm(n)%physics_tendency_diag, nt_dyn, dt_atmos, .false.)
 
    call timing_off('GFS_TENDENCIES')
 
@@ -1659,7 +1659,7 @@ contains
                          Atm(n)%gridstruct%agrid(:,:,1), Atm(n)%gridstruct%agrid(:,:,2),   &
                          Atm(n)%npx, Atm(n)%npy, Atm(n)%npz, Atm(n)%flagstruct,            &
                          Atm(n)%neststruct, Atm(n)%bd, Atm(n)%domain, Atm(n)%ptop,         &
-                         Atm(n)%nudge_diag, Atm(n)%phys_diag)
+                         Atm(n)%nudge_diag, Atm(n)%physics_tendency_diag)
        call timing_off('FV_UPDATE_PHYS')
    call mpp_clock_end (id_dynam)
 
@@ -2183,21 +2183,21 @@ contains
 
  end subroutine atmos_phys_driver_statein
 
- subroutine atmos_phys_qdt_diag(q, phys_diag, nq, dt, begin)
+ subroutine atmos_phys_qdt_diag(q, physics_tendency_diag, nq, dt, begin)
    integer, intent(in) :: nq
    real, intent(in) :: q(isd:ied,jsd:jed,1:npz,1:nq)
    real, intent(in) :: dt
    logical, intent(in) :: begin
-   type(phys_diag_type), intent(inout) :: phys_diag
+   type(physics_tendency_diag_type), intent(inout) :: physics_tendency_diag
 
    integer :: sphum
 
    sphum = get_tracer_index (MODEL_ATMOS, 'sphum')
 
    if (begin) then
-      if (allocated(phys_diag%qv_dt)) phys_diag%qv_dt = q(isc:iec,jsc:jec,1:npz,sphum)
+      if (allocated(physics_tendency_diag%qv_dt)) physics_tendency_diag%qv_dt = q(isc:iec,jsc:jec,1:npz,sphum)
    else
-      if (allocated(phys_diag%qv_dt)) phys_diag%qv_dt = (q(isc:iec,jsc:jec,1:npz,sphum) - phys_diag%qv_dt) / dt
+      if (allocated(physics_tendency_diag%qv_dt)) physics_tendency_diag%qv_dt = (q(isc:iec,jsc:jec,1:npz,sphum) - physics_tendency_diag%qv_dt) / dt
    endif
  end subroutine atmos_phys_qdt_diag
 

--- a/FV3/atmos_cubed_sphere/driver/fvGFS/atmosphere.F90
+++ b/FV3/atmos_cubed_sphere/driver/fvGFS/atmosphere.F90
@@ -2179,9 +2179,8 @@ contains
            enddo
         enddo
     endif
+    IPD_Data(nb)%Statein%dycore_hydrostatic = Atm(mytile)%flagstruct%hydrostatic
   enddo
-
-  IPD_Data(nb)%Statein%dycore_hydrostatic = Atm(mytile)%flagstruct%hydrostatic
 
  end subroutine atmos_phys_driver_statein
 

--- a/FV3/atmos_cubed_sphere/driver/fvGFS/atmosphere.F90
+++ b/FV3/atmos_cubed_sphere/driver/fvGFS/atmosphere.F90
@@ -2181,6 +2181,8 @@ contains
     endif
   enddo
 
+  IPD_Data(nb)%Statein%dycore_hydrostatic = Atm(mytile)%flagstruct%hydrostatic
+
  end subroutine atmos_phys_driver_statein
 
  subroutine atmos_phys_qdt_diag(q, physics_tendency_diag, nq, dt, begin)

--- a/FV3/atmos_cubed_sphere/model/fv_arrays.F90
+++ b/FV3/atmos_cubed_sphere/model/fv_arrays.F90
@@ -1143,12 +1143,12 @@ module fv_arrays_mod
 
    end type nudge_diag_type
 
-   type phys_diag_type
+   type physics_tendency_diag_type
 
       real, allocatable :: t_dt(:,:,:)
       real, allocatable :: qv_dt(:,:,:)
 
-   end type phys_diag_type
+   end type physics_tendency_diag_type
 !>@brief 'allocate_fv_nest_BC_type' is an interface to subroutines
 !! that allocate the 'fv_nest_BC_type' structure that holds the nested-grid BCs.
 !>@details The subroutines can pass the array bounds explicitly or not.
@@ -1392,7 +1392,7 @@ module fv_arrays_mod
 
   type(nudge_diag_type) :: nudge_diag
 
-  type(phys_diag_type) :: phys_diag
+  type(physics_tendency_diag_type) :: physics_tendency_diag
 
   type(fv_coarse_graining_type) :: coarse_graining
 

--- a/FV3/atmos_cubed_sphere/model/fv_arrays.F90
+++ b/FV3/atmos_cubed_sphere/model/fv_arrays.F90
@@ -114,6 +114,7 @@ module fv_arrays_mod
      integer :: id_t_dt_nudge, id_ps_dt_nudge, id_delp_dt_nudge
      integer :: id_u_dt_nudge, id_v_dt_nudge, id_q_dt_nudge
      integer :: id_t_dt_phys, id_qv_dt_phys
+     integer :: id_cvm
 
   end type fv_diag_type
 

--- a/FV3/atmos_cubed_sphere/model/fv_arrays.F90
+++ b/FV3/atmos_cubed_sphere/model/fv_arrays.F90
@@ -114,7 +114,7 @@ module fv_arrays_mod
      integer :: id_t_dt_nudge, id_ps_dt_nudge, id_delp_dt_nudge
      integer :: id_u_dt_nudge, id_v_dt_nudge, id_q_dt_nudge
      integer :: id_t_dt_phys, id_qv_dt_phys
-     integer :: id_cvm
+     integer :: id_cvm, id_cpm
 
   end type fv_diag_type
 

--- a/FV3/atmos_cubed_sphere/model/fv_arrays.F90
+++ b/FV3/atmos_cubed_sphere/model/fv_arrays.F90
@@ -113,6 +113,7 @@ module fv_arrays_mod
 
      integer :: id_t_dt_nudge, id_ps_dt_nudge, id_delp_dt_nudge
      integer :: id_u_dt_nudge, id_v_dt_nudge, id_q_dt_nudge
+     integer :: id_t_dt_phys, id_qv_dt_phys
 
   end type fv_diag_type
 
@@ -1141,6 +1142,12 @@ module fv_arrays_mod
 
    end type nudge_diag_type
 
+   type phys_diag_type
+
+      real, allocatable :: t_dt(:,:,:)
+      real, allocatable :: qv_dt(:,:,:)
+
+   end type phys_diag_type
 !>@brief 'allocate_fv_nest_BC_type' is an interface to subroutines
 !! that allocate the 'fv_nest_BC_type' structure that holds the nested-grid BCs.
 !>@details The subroutines can pass the array bounds explicitly or not.
@@ -1383,6 +1390,8 @@ module fv_arrays_mod
   integer :: atmos_axes(4)
 
   type(nudge_diag_type) :: nudge_diag
+
+  type(phys_diag_type) :: phys_diag
 
   type(fv_coarse_graining_type) :: coarse_graining
 

--- a/FV3/atmos_cubed_sphere/model/fv_arrays.F90
+++ b/FV3/atmos_cubed_sphere/model/fv_arrays.F90
@@ -114,7 +114,6 @@ module fv_arrays_mod
      integer :: id_t_dt_nudge, id_ps_dt_nudge, id_delp_dt_nudge
      integer :: id_u_dt_nudge, id_v_dt_nudge, id_q_dt_nudge
      integer :: id_t_dt_phys, id_qv_dt_phys
-     integer :: id_cvm, id_cpm
 
   end type fv_diag_type
 

--- a/FV3/atmos_cubed_sphere/model/fv_update_phys.F90
+++ b/FV3/atmos_cubed_sphere/model/fv_update_phys.F90
@@ -99,7 +99,7 @@ module fv_update_phys_mod
   use tracer_manager_mod, only: get_tracer_index, adjust_mass, get_tracer_names
   use fv_mp_mod,          only: start_group_halo_update, complete_group_halo_update
   use fv_mp_mod,          only: group_halo_update_type
-  use fv_arrays_mod,      only: fv_flags_type, fv_nest_type, R_GRID, nudge_diag_type, phys_diag_type
+  use fv_arrays_mod,      only: fv_flags_type, fv_nest_type, R_GRID, nudge_diag_type, physics_tendency_diag_type
   use boundary_mod,       only: nested_grid_BC
   use boundary_mod,       only: extrapolation_BC
   use fv_eta_mod,         only: get_eta_level
@@ -137,7 +137,7 @@ module fv_update_phys_mod
                               ak, bk, phis, u_srf, v_srf, ts, delz, hydrostatic,  &
                               u_dt, v_dt, t_dt, moist_phys, Time, nudge,    &
                               gridstruct, lona, lata, npx, npy, npz, flagstruct,  &
-                              neststruct, bd, domain, ptop, nudge_diag, phys_diag, &
+                              neststruct, bd, domain, ptop, nudge_diag, physics_tendency_diag, &
                               q_dt)
     real, intent(in)   :: dt, ptop
     integer, intent(in):: is,  ie,  js,  je, ng
@@ -198,7 +198,7 @@ module fv_update_phys_mod
     integer, intent(IN) :: npx, npy, npz
 
     type(nudge_diag_type), intent(inout) :: nudge_diag
-    type(phys_diag_type), intent(inout) :: phys_diag
+    type(physics_tendency_diag_type), intent(inout) :: physics_tendency_diag
 
 !***********
 ! Haloe Data
@@ -295,7 +295,7 @@ module fv_update_phys_mod
 
     call get_eta_level(npz, 1.0E5, pfull, phalf, ak, bk)
 
-    if (allocated(phys_diag%t_dt)) phys_diag%t_dt = pt(is:ie,js:je,:)
+    if (allocated(physics_tendency_diag%t_dt)) physics_tendency_diag%t_dt = pt(is:ie,js:je,:)
 
 #ifdef MULTI_GASES
         nm = max(           nwat,num_gas)
@@ -464,7 +464,7 @@ module fv_update_phys_mod
 
     enddo ! k-loop
 
-if (allocated(phys_diag%t_dt)) phys_diag%t_dt = (pt(is:ie,js:je,:) - phys_diag%t_dt) / dt
+if (allocated(physics_tendency_diag%t_dt)) physics_tendency_diag%t_dt = (pt(is:ie,js:je,:) - physics_tendency_diag%t_dt) / dt
 
 ! [delp, (ua, va), pt, q] updated. Perform nudging if requested
 !------- nudging of atmospheric variables toward specified data --------

--- a/FV3/atmos_cubed_sphere/model/fv_update_phys.F90
+++ b/FV3/atmos_cubed_sphere/model/fv_update_phys.F90
@@ -99,7 +99,7 @@ module fv_update_phys_mod
   use tracer_manager_mod, only: get_tracer_index, adjust_mass, get_tracer_names
   use fv_mp_mod,          only: start_group_halo_update, complete_group_halo_update
   use fv_mp_mod,          only: group_halo_update_type
-  use fv_arrays_mod,      only: fv_flags_type, fv_nest_type, R_GRID, nudge_diag_type
+  use fv_arrays_mod,      only: fv_flags_type, fv_nest_type, R_GRID, nudge_diag_type, phys_diag_type
   use boundary_mod,       only: nested_grid_BC
   use boundary_mod,       only: extrapolation_BC
   use fv_eta_mod,         only: get_eta_level
@@ -137,7 +137,8 @@ module fv_update_phys_mod
                               ak, bk, phis, u_srf, v_srf, ts, delz, hydrostatic,  &
                               u_dt, v_dt, t_dt, moist_phys, Time, nudge,    &
                               gridstruct, lona, lata, npx, npy, npz, flagstruct,  &
-                              neststruct, bd, domain, ptop, nudge_diag, q_dt)
+                              neststruct, bd, domain, ptop, nudge_diag, phys_diag, &
+                              q_dt)
     real, intent(in)   :: dt, ptop
     integer, intent(in):: is,  ie,  js,  je, ng
     integer, intent(in):: isd, ied, jsd, jed
@@ -197,6 +198,7 @@ module fv_update_phys_mod
     integer, intent(IN) :: npx, npy, npz
 
     type(nudge_diag_type), intent(inout) :: nudge_diag
+    type(phys_diag_type), intent(inout) :: phys_diag
 
 !***********
 ! Haloe Data
@@ -292,6 +294,8 @@ module fv_update_phys_mod
     endif
 
     call get_eta_level(npz, 1.0E5, pfull, phalf, ak, bk)
+
+    if (allocated(phys_diag%t_dt)) phys_diag%t_dt = pt(is:ie,js:je,:)
 
 #ifdef MULTI_GASES
         nm = max(           nwat,num_gas)
@@ -459,6 +463,8 @@ module fv_update_phys_mod
 #endif
 
     enddo ! k-loop
+
+if (allocated(phys_diag%t_dt)) phys_diag%t_dt = (pt(is:ie,js:je,:) - phys_diag%t_dt) / dt
 
 ! [delp, (ua, va), pt, q] updated. Perform nudging if requested
 !------- nudging of atmospheric variables toward specified data --------

--- a/FV3/atmos_cubed_sphere/tools/fv_diagnostics.F90
+++ b/FV3/atmos_cubed_sphere/tools/fv_diagnostics.F90
@@ -1083,7 +1083,7 @@ contains
           missing_value=missing_value)
     if (idiag%id_t_dt_phys > 0) then
          allocate(Atm(n)%physics_tendency_diag%t_dt(isc:iec,jsc:jec,npz))
-         Atm(n)%physics_tendency_diag%t_dt(isc:iec,jsc:jec,1:npz) = 0.0
+         Atm(n)%physics_tendency_diag%t_dt = 0.0
     endif
 
     idiag%id_qv_dt_phys = register_diag_field('dynamics', &
@@ -1092,7 +1092,7 @@ contains
           missing_value=missing_value)
     if (idiag%id_qv_dt_phys > 0) then
          allocate(Atm(n)%physics_tendency_diag%qv_dt(isc:iec,jsc:jec,npz))
-         Atm(n)%physics_tendency_diag%qv_dt(isc:iec,jsc:jec,1:npz) = 0.0
+         Atm(n)%physics_tendency_diag%qv_dt = 0.0
     endif
  end subroutine fv_diag_init
 

--- a/FV3/atmos_cubed_sphere/tools/fv_diagnostics.F90
+++ b/FV3/atmos_cubed_sphere/tools/fv_diagnostics.F90
@@ -1082,8 +1082,8 @@ contains
           'temperature tendency from physics', 'K/s', &
           missing_value=missing_value)
     if (idiag%id_t_dt_phys > 0) then
-         allocate(Atm(n)%phys_diag%t_dt(isc:iec,jsc:jec,npz))
-         Atm(n)%phys_diag%t_dt(isc:iec,jsc:jec,1:npz) = 0.0
+         allocate(Atm(n)%physics_tendency_diag%t_dt(isc:iec,jsc:jec,npz))
+         Atm(n)%physics_tendency_diag%t_dt(isc:iec,jsc:jec,1:npz) = 0.0
     endif
 
     idiag%id_qv_dt_phys = register_diag_field('dynamics', &
@@ -1091,8 +1091,8 @@ contains
           'specific humidity tendency from physics', 'kg/kg/s', &
           missing_value=missing_value)
     if (idiag%id_qv_dt_phys > 0) then
-         allocate(Atm(n)%phys_diag%qv_dt(isc:iec,jsc:jec,npz))
-         Atm(n)%phys_diag%qv_dt(isc:iec,jsc:jec,1:npz) = 0.0
+         allocate(Atm(n)%physics_tendency_diag%qv_dt(isc:iec,jsc:jec,npz))
+         Atm(n)%physics_tendency_diag%qv_dt(isc:iec,jsc:jec,1:npz) = 0.0
     endif
 
     idiag%id_cvm = register_diag_field('dynamics', &
@@ -3124,10 +3124,10 @@ contains
      endif
 
      if (idiag%id_t_dt_phys > 0) then
-        used = send_data(idiag%id_t_dt_phys, Atm(n)%phys_diag%t_dt(isc:iec,jsc:jec,1:npz), Time)
+        used = send_data(idiag%id_t_dt_phys, Atm(n)%physics_tendency_diag%t_dt(isc:iec,jsc:jec,1:npz), Time)
      endif
      if (idiag%id_qv_dt_phys > 0) then
-        used = send_data(idiag%id_qv_dt_phys, Atm(n)%phys_diag%qv_dt(isc:iec,jsc:jec,1:npz), Time)
+        used = send_data(idiag%id_qv_dt_phys, Atm(n)%physics_tendency_diag%qv_dt(isc:iec,jsc:jec,1:npz), Time)
      endif
      if (idiag%id_cvm > 0) then
         call compute_cvm(Atm(n)%q(isd:ied,jsd:jed,1:npz,1:Atm(n)%flagstruct%nwat), Atm(n)%pt(isd:ied,jsd:jed,1:npz), &

--- a/FV3/atmos_cubed_sphere/tools/fv_diagnostics.F90
+++ b/FV3/atmos_cubed_sphere/tools/fv_diagnostics.F90
@@ -1077,6 +1077,24 @@ contains
         Atm(n)%nudge_diag%nudge_v_dt(isc:iec,jsc:jec,npz) = 0.0
     endif
 
+    idiag%id_t_dt_phys = register_diag_field('dynamics', &
+          't_dt_phys', axes(1:3), Time, &
+          'temperature tendency from physics', 'K/s', &
+          missing_value=missing_value)
+    if (idiag%id_t_dt_phys > 0) then
+         allocate(Atm(n)%phys_diag%t_dt(isc:iec,jsc:jec,npz))
+         Atm(n)%phys_diag%t_dt(isc:iec,jsc:jec,1:npz) = 0.0
+    endif
+
+    idiag%id_qv_dt_phys = register_diag_field('dynamics', &
+          'qv_dt_phys', axes(1:3), Time, &
+          'specific humidity tendency from physics', 'kg/kg/s', &
+          missing_value=missing_value)
+    if (idiag%id_qv_dt_phys > 0) then
+         allocate(Atm(n)%phys_diag%qv_dt(isc:iec,jsc:jec,npz))
+         Atm(n)%phys_diag%qv_dt(isc:iec,jsc:jec,1:npz) = 0.0
+    endif
+
  end subroutine fv_diag_init
 
 
@@ -3099,6 +3117,13 @@ contains
      endif
      if (idiag%id_v_dt_nudge > 0) then
         used = send_data(idiag%id_v_dt_nudge, Atm(n)%nudge_diag%nudge_v_dt(isc:iec,jsc:jec,1:npz), Time)
+     endif
+
+     if (idiag%id_t_dt_phys > 0) then
+        used = send_data(idiag%id_t_dt_phys, Atm(n)%phys_diag%t_dt(isc:iec,jsc:jec,1:npz), Time)
+     endif
+     if (idiag%id_qv_dt_phys > 0) then
+        used = send_data(idiag%id_qv_dt_phys, Atm(n)%phys_diag%qv_dt(isc:iec,jsc:jec,1:npz), Time)
      endif
    ! enddo  ! end ntileMe do-loop
 

--- a/FV3/atmos_cubed_sphere/tools/fv_diagnostics.F90
+++ b/FV3/atmos_cubed_sphere/tools/fv_diagnostics.F90
@@ -1203,7 +1203,6 @@ contains
     logical, allocatable :: storm(:,:), cat_crt(:,:)
     real :: tmp2, pvsum, e2, einf, qm, mm, maxdbz, allmax, rgrav
     integer :: Cl, Cl2
-    integer :: ntracers, ntprog
     !!! CLEANUP: does it really make sense to have this routine loop over Atm% anymore? We assume n=1 below anyway
 
 ! cat15: SLP<1000; srf_wnd>ws_0; vort>vort_c0
@@ -3131,9 +3130,8 @@ contains
         used = send_data(idiag%id_qv_dt_phys, Atm(n)%phys_diag%qv_dt(isc:iec,jsc:jec,1:npz), Time)
      endif
      if (idiag%id_cvm > 0) then
-        call get_number_tracers(MODEL_ATMOS, num_tracers=ntracers, num_prog=ntprog)
-        call compute_cvm(Atm(n)%q(isc:iec,jsc:jec,1:npz,1:ntprog), Atm(n)%pt(isc:iec,jsc:jec,1:npz), &
-             isc, iec, jsc, jec, npz, isd, ied, jsd, jed, ntprog, Atm(n)%flagstruct%nwat, wk(isc:iec,jsc:jec,1:npz))
+        call compute_cvm(Atm(n)%q(isd:ied,jsd:jed,1:npz,1:Atm(n)%flagstruct%nwat), Atm(n)%pt(isd:ied,jsd:jed,1:npz), &
+             isc, iec, jsc, jec, npz, isd, ied, jsd, jed, Atm(n)%flagstruct%nwat, wk(isc:iec,jsc:jec,1:npz))
         used = send_data(idiag%id_cvm, wk(isc:iec,jsc:jec,1:npz), Time)
      endif
    ! enddo  ! end ntileMe do-loop
@@ -5717,10 +5715,10 @@ end subroutine eqv_pot
   end function getqvi
 !-----------------------------------------------------------------------
 
-  subroutine compute_cvm(q, pt, isc, iec, jsc, jec, npz, isd, ied, jsd, jed, ntprog, nwat, cvm)
-   integer :: isc, iec, jsc, jec, npz, isd, ied, jsd, jed, ntprog, nwat
-   real, dimension(isc:iec,jsc:jec,1:npz,1:ntprog), intent(in) :: q
-   real, dimension(isc:iec,jsc:jec,1:npz), intent(in) :: pt
+  subroutine compute_cvm(q, pt, isc, iec, jsc, jec, npz, isd, ied, jsd, jed, nwat, cvm)
+   integer :: isc, iec, jsc, jec, npz, isd, ied, jsd, jed, nwat
+   real, dimension(isd:ied,jsd:jed,1:npz,1:nwat), intent(in) :: q
+   real, dimension(isd:ied,jsd:jed,1:npz), intent(in) :: pt
    real, dimension(isc:iec,jsc:jec,1:npz), intent(out) :: cvm
    real, dimension(isc:iec) :: qc, cvm_tmp
    integer :: j, k, sphum, liq_wat, ice_wat, rainwat, snowwat, graupel

--- a/FV3/atmos_cubed_sphere/tools/fv_diagnostics.F90
+++ b/FV3/atmos_cubed_sphere/tools/fv_diagnostics.F90
@@ -128,7 +128,7 @@ module fv_diagnostics_mod
  use fv_arrays_mod,      only: fv_atmos_type, fv_grid_type, fv_diag_type, fv_grid_bounds_type, & 
                                R_GRID
  !!! CLEANUP needs rem oval?
- use fv_mapz_mod,        only: E_Flux, moist_cv, moist_cp
+ use fv_mapz_mod,        only: E_Flux, moist_cv
  use fv_mp_mod,          only: mp_reduce_sum, mp_reduce_min, mp_reduce_max, is_master
  use fv_eta_mod,         only: get_eta_level, gw_1d
  use fv_grid_utils_mod,  only: g_sum
@@ -1094,16 +1094,6 @@ contains
          allocate(Atm(n)%physics_tendency_diag%qv_dt(isc:iec,jsc:jec,npz))
          Atm(n)%physics_tendency_diag%qv_dt(isc:iec,jsc:jec,1:npz) = 0.0
     endif
-
-    idiag%id_cvm = register_diag_field('dynamics', &
-          'cvm', axes(1:3), Time, &
-          'moist specific heat of air at constant volume', 'J/kg/K', &
-          missing_value=missing_value)
-
-    idiag%id_cpm = register_diag_field('dynamics', &
-          'cpm', axes(1:3), Time, &
-          'moist specific heat of air at constant pressure', 'J/kg/K', &
-          missing_value=missing_value)
  end subroutine fv_diag_init
 
 
@@ -3134,16 +3124,6 @@ contains
      if (idiag%id_qv_dt_phys > 0) then
         used = send_data(idiag%id_qv_dt_phys, Atm(n)%physics_tendency_diag%qv_dt(isc:iec,jsc:jec,1:npz), Time)
      endif
-     if (idiag%id_cvm > 0) then
-        call compute_cvm(Atm(n)%q(isd:ied,jsd:jed,1:npz,1:Atm(n)%flagstruct%nwat), Atm(n)%pt(isd:ied,jsd:jed,1:npz), &
-             isc, iec, jsc, jec, npz, isd, ied, jsd, jed, Atm(n)%flagstruct%nwat, wk(isc:iec,jsc:jec,1:npz))
-        used = send_data(idiag%id_cvm, wk(isc:iec,jsc:jec,1:npz), Time)
-     endif
-     if (idiag%id_cpm > 0) then
-      call compute_cpm(Atm(n)%q(isd:ied,jsd:jed,1:npz,1:Atm(n)%flagstruct%nwat), Atm(n)%pt(isd:ied,jsd:jed,1:npz), &
-           isc, iec, jsc, jec, npz, isd, ied, jsd, jed, Atm(n)%flagstruct%nwat, wk(isc:iec,jsc:jec,1:npz))
-      used = send_data(idiag%id_cpm, wk(isc:iec,jsc:jec,1:npz), Time)
-   endif
    ! enddo  ! end ntileMe do-loop
 
     deallocate ( a2 )
@@ -5724,55 +5704,5 @@ end subroutine eqv_pot
     return
   end function getqvi
 !-----------------------------------------------------------------------
-
-  subroutine compute_cvm(q, pt, isc, iec, jsc, jec, npz, isd, ied, jsd, jed, nwat, cvm)
-   integer :: isc, iec, jsc, jec, npz, isd, ied, jsd, jed, nwat
-   real, dimension(isd:ied,jsd:jed,1:npz,1:nwat), intent(in) :: q
-   real, dimension(isd:ied,jsd:jed,1:npz), intent(in) :: pt
-   real, dimension(isc:iec,jsc:jec,1:npz), intent(out) :: cvm
-   real, dimension(isc:iec) :: qc, cvm_tmp
-   integer :: j, k, sphum, liq_wat, ice_wat, rainwat, snowwat, graupel
-
-   sphum = get_tracer_index (MODEL_ATMOS, 'sphum')
-   liq_wat = get_tracer_index (MODEL_ATMOS, 'liq_wat')
-   ice_wat = get_tracer_index (MODEL_ATMOS, 'ice_wat')
-   rainwat = get_tracer_index (MODEL_ATMOS, 'rainwat')
-   snowwat = get_tracer_index (MODEL_ATMOS, 'snowwat')
-   graupel = get_tracer_index (MODEL_ATMOS, 'graupel')
-
-   do j = jsc, jec
-      do k = 1, npz
-         call moist_cv(isc, iec, isd, ied, jsd, jed, npz, j, k, nwat, sphum, &
-              liq_wat, rainwat, ice_wat, snowwat, graupel, &
-              q, qc, cvm_tmp, pt(isc:iec,j,k))
-         cvm(isc:iec,j,k) = cvm_tmp
-      enddo
-   enddo
- end subroutine compute_cvm
-
- subroutine compute_cpm(q, pt, isc, iec, jsc, jec, npz, isd, ied, jsd, jed, nwat, cpm)
-   integer :: isc, iec, jsc, jec, npz, isd, ied, jsd, jed, nwat
-   real, dimension(isd:ied,jsd:jed,1:npz,1:nwat), intent(in) :: q
-   real, dimension(isd:ied,jsd:jed,1:npz), intent(in) :: pt
-   real, dimension(isc:iec,jsc:jec,1:npz), intent(out) :: cpm
-   real, dimension(isc:iec) :: qc, cpm_tmp
-   integer :: j, k, sphum, liq_wat, ice_wat, rainwat, snowwat, graupel
-
-   sphum = get_tracer_index (MODEL_ATMOS, 'sphum')
-   liq_wat = get_tracer_index (MODEL_ATMOS, 'liq_wat')
-   ice_wat = get_tracer_index (MODEL_ATMOS, 'ice_wat')
-   rainwat = get_tracer_index (MODEL_ATMOS, 'rainwat')
-   snowwat = get_tracer_index (MODEL_ATMOS, 'snowwat')
-   graupel = get_tracer_index (MODEL_ATMOS, 'graupel')
-
-   do j = jsc, jec
-      do k = 1, npz
-         call moist_cp(isc, iec, isd, ied, jsd, jed, npz, j, k, nwat, sphum, &
-              liq_wat, rainwat, ice_wat, snowwat, graupel, &
-              q, qc, cpm_tmp, pt(isc:iec,j,k))
-         cpm(isc:iec,j,k) = cpm_tmp
-      enddo
-   enddo
- end subroutine compute_cpm
 
 end module fv_diagnostics_mod

--- a/FV3/gfsphysics/GFS_layer/GFS_diagnostics.F90
+++ b/FV3/gfsphysics/GFS_layer/GFS_diagnostics.F90
@@ -2532,7 +2532,7 @@ module GFS_diagnostics
 
     idx = idx + 1
     ExtDiag(idx)%axes = 3
-    ExtDiag(idx)%name = 'dq3dt_microphys'
+    ExtDiag(idx)%name = 'dq3dt_microphy'
     ExtDiag(idx)%desc = 'water vapor change due to microphysics'
     ExtDiag(idx)%unit = 'kg/kg'
     ExtDiag(idx)%mod_name = 'gfs_phys'
@@ -2583,7 +2583,7 @@ module GFS_diagnostics
 
     idx = idx + 1
     ExtDiag(idx)%axes = 3
-    ExtDiag(idx)%name = 'qv_dt_microphys'
+    ExtDiag(idx)%name = 'qv_dt_microphy'
     ExtDiag(idx)%desc = 'water vapor tendency due to microphysics'
     ExtDiag(idx)%unit = 'kg/kg/s'
     ExtDiag(idx)%mod_name = 'gfs_phys'

--- a/FV3/gfsphysics/GFS_layer/GFS_diagnostics.F90
+++ b/FV3/gfsphysics/GFS_layer/GFS_diagnostics.F90
@@ -2398,14 +2398,14 @@ module GFS_diagnostics
 
     idx = idx + 1
     ExtDiag(idx)%axes = 3
-    ExtDiag(idx)%name = 'cvm_phys'
-    ExtDiag(idx)%desc = 'moist specific heat of air at constant volume'
+    ExtDiag(idx)%name = 'c_phys'
+    ExtDiag(idx)%desc = 'moist specific heat of air at constant volume (if non-hydrostatic dycore) or constant pressure (if hydrostatic dycore)'
     ExtDiag(idx)%unit = 'J/kg/K'
     ExtDiag(idx)%time_avg = .true.
     ExtDiag(idx)%mod_name = 'gfs_phys'
     allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var3 => IntDiag(nb)%cvm(:,:)
+      ExtDiag(idx)%data(nb)%var3 => IntDiag(nb)%specific_heat(:,:)
     enddo
 
     idx = idx + 1

--- a/FV3/gfsphysics/GFS_layer/GFS_diagnostics.F90
+++ b/FV3/gfsphysics/GFS_layer/GFS_diagnostics.F90
@@ -2495,6 +2495,97 @@ module GFS_diagnostics
       ExtDiag(idx)%data(nb)%var3 => IntDiag(nb)%dv3dt(:,:,4)
     enddo
 
+    idx = idx + 1
+    ExtDiag(idx)%axes = 3
+    ExtDiag(idx)%name = 'dq3dt_pbl'
+    ExtDiag(idx)%desc = 'water vapor change due to turbulence scheme'
+    ExtDiag(idx)%unit = 'kg/kg'
+    ExtDiag(idx)%mod_name = 'gfs_phys'
+    allocate (ExtDiag(idx)%data(nblks))
+    do nb = 1,nblks
+      ExtDiag(idx)%data(nb)%var3 => IntDiag(nb)%dq3dt(:,:,1)
+    enddo
+
+    idx = idx + 1
+    ExtDiag(idx)%axes = 3
+    ExtDiag(idx)%name = 'dq3dt_deepcnv'
+    ExtDiag(idx)%desc = 'water vapor change due to deep convection'
+    ExtDiag(idx)%unit = 'kg/kg'
+    ExtDiag(idx)%mod_name = 'gfs_phys'
+    allocate (ExtDiag(idx)%data(nblks))
+    do nb = 1,nblks
+      ExtDiag(idx)%data(nb)%var3 => IntDiag(nb)%dq3dt(:,:,2)
+    enddo
+
+    idx = idx + 1
+    ExtDiag(idx)%axes = 3
+    ExtDiag(idx)%name = 'dq3dt_shlwcnv'
+    ExtDiag(idx)%desc = 'water vapor change due to shallow convection'
+    ExtDiag(idx)%unit = 'kg/kg'
+    ExtDiag(idx)%mod_name = 'gfs_phys'
+    allocate (ExtDiag(idx)%data(nblks))
+    do nb = 1,nblks
+      ExtDiag(idx)%data(nb)%var3 => IntDiag(nb)%dq3dt(:,:,3)
+    enddo
+
+    idx = idx + 1
+    ExtDiag(idx)%axes = 3
+    ExtDiag(idx)%name = 'dq3dt_microphys'
+    ExtDiag(idx)%desc = 'water vapor change due to microphysics'
+    ExtDiag(idx)%unit = 'kg/kg'
+    ExtDiag(idx)%mod_name = 'gfs_phys'
+    allocate (ExtDiag(idx)%data(nblks))
+    do nb = 1,nblks
+      ExtDiag(idx)%data(nb)%var3 => IntDiag(nb)%dq3dt(:,:,4)
+    enddo
+
+    idx = idx + 1
+    ExtDiag(idx)%axes = 3
+    ExtDiag(idx)%name = 'qv_dt_pbl'
+    ExtDiag(idx)%desc = 'water vapor tendency due to turbulence scheme'
+    ExtDiag(idx)%unit = 'kg/kg/s'
+    ExtDiag(idx)%mod_name = 'gfs_phys'
+    ExtDiag(idx)%time_avg = .true.
+    allocate (ExtDiag(idx)%data(nblks))
+    do nb = 1,nblks
+      ExtDiag(idx)%data(nb)%var3 => IntDiag(nb)%q_dt(:,:,1)
+    enddo
+
+    idx = idx + 1
+    ExtDiag(idx)%axes = 3
+    ExtDiag(idx)%name = 'qv_dt_deepcnv'
+    ExtDiag(idx)%desc = 'water vapor tendency due to deep convection'
+    ExtDiag(idx)%unit = 'kg/kg/s'
+    ExtDiag(idx)%mod_name = 'gfs_phys'
+    ExtDiag(idx)%time_avg = .true.
+    allocate (ExtDiag(idx)%data(nblks))
+    do nb = 1,nblks
+      ExtDiag(idx)%data(nb)%var3 => IntDiag(nb)%q_dt(:,:,2)
+    enddo
+
+    idx = idx + 1
+    ExtDiag(idx)%axes = 3
+    ExtDiag(idx)%name = 'qv_dt_shlwcnv'
+    ExtDiag(idx)%desc = 'water vapor tendency due to shallow convection'
+    ExtDiag(idx)%unit = 'kg/kg/s'
+    ExtDiag(idx)%mod_name = 'gfs_phys'
+    ExtDiag(idx)%time_avg = .true.
+    allocate (ExtDiag(idx)%data(nblks))
+    do nb = 1,nblks
+      ExtDiag(idx)%data(nb)%var3 => IntDiag(nb)%q_dt(:,:,3)
+    enddo
+
+    idx = idx + 1
+    ExtDiag(idx)%axes = 3
+    ExtDiag(idx)%name = 'qv_dt_microphys'
+    ExtDiag(idx)%desc = 'water vapor tendency due to microphysics'
+    ExtDiag(idx)%unit = 'kg/kg/s'
+    ExtDiag(idx)%mod_name = 'gfs_phys'
+    ExtDiag(idx)%time_avg = .true.
+    allocate (ExtDiag(idx)%data(nblks))
+    do nb = 1,nblks
+      ExtDiag(idx)%data(nb)%var3 => IntDiag(nb)%q_dt(:,:,4)
+    enddo
 
 !rab
 !rab    do num = 1,5+Mdl_parms%pl_coeff

--- a/FV3/gfsphysics/GFS_layer/GFS_diagnostics.F90
+++ b/FV3/gfsphysics/GFS_layer/GFS_diagnostics.F90
@@ -2308,6 +2308,104 @@ module GFS_diagnostics
       ExtDiag(idx)%data(nb)%var3 => IntDiag(nb)%dt3dt(:,:,7)
     enddo
 
+! Add *time_avg* versions of the existing dt3dt diagnostics; this converts
+! them to tendencies.
+    idx = idx + 1
+    ExtDiag(idx)%axes = 3
+    ExtDiag(idx)%name = 't_dt_lw'
+    ExtDiag(idx)%desc = 'temperature tendency due to longwave radiation'
+    ExtDiag(idx)%unit = 'K/s'
+    ExtDiag(idx)%time_avg = .true.
+    ExtDiag(idx)%mod_name = 'gfs_phys'
+    allocate (ExtDiag(idx)%data(nblks))
+    do nb = 1,nblks
+      ExtDiag(idx)%data(nb)%var3 => IntDiag(nb)%t_dt(:,:,1)
+    enddo
+
+    idx = idx + 1
+    ExtDiag(idx)%axes = 3
+    ExtDiag(idx)%name = 't_dt_sw'
+    ExtDiag(idx)%desc = 'temperature tendency due to shortwave radiation'
+    ExtDiag(idx)%unit = 'K/s'
+    ExtDiag(idx)%time_avg = .true.
+    ExtDiag(idx)%mod_name = 'gfs_phys'
+    allocate (ExtDiag(idx)%data(nblks))
+    do nb = 1,nblks
+      ExtDiag(idx)%data(nb)%var3 => IntDiag(nb)%t_dt(:,:,2)
+    enddo
+
+    idx = idx + 1
+    ExtDiag(idx)%axes = 3
+    ExtDiag(idx)%name = 't_dt_pbl'
+    ExtDiag(idx)%desc = 'temperature tendency due to pbl'
+    ExtDiag(idx)%unit = 'K/s'
+    ExtDiag(idx)%time_avg = .true.
+    ExtDiag(idx)%mod_name = 'gfs_phys'
+    allocate (ExtDiag(idx)%data(nblks))
+    do nb = 1,nblks
+      ExtDiag(idx)%data(nb)%var3 => IntDiag(nb)%t_dt(:,:,3)
+    enddo
+
+    idx = idx + 1
+    ExtDiag(idx)%axes = 3
+    ExtDiag(idx)%name = 't_dt_deepcnv'
+    ExtDiag(idx)%desc = 'temperature tendency due to deep convection'
+    ExtDiag(idx)%unit = 'K/s'
+    ExtDiag(idx)%time_avg = .true.
+    ExtDiag(idx)%mod_name = 'gfs_phys'
+    allocate (ExtDiag(idx)%data(nblks))
+    do nb = 1,nblks
+      ExtDiag(idx)%data(nb)%var3 => IntDiag(nb)%t_dt(:,:,4)
+    enddo
+
+    idx = idx + 1
+    ExtDiag(idx)%axes = 3
+    ExtDiag(idx)%name = 't_dt_shlwcnv'
+    ExtDiag(idx)%desc = 'temperature tendency due to shallow convection'
+    ExtDiag(idx)%unit = 'K/s'
+    ExtDiag(idx)%time_avg = .true.
+    ExtDiag(idx)%mod_name = 'gfs_phys'
+    allocate (ExtDiag(idx)%data(nblks))
+    do nb = 1,nblks
+      ExtDiag(idx)%data(nb)%var3 => IntDiag(nb)%t_dt(:,:,5)
+    enddo
+
+    idx = idx + 1
+    ExtDiag(idx)%axes = 3
+    ExtDiag(idx)%name = 't_dt_microphy'
+    ExtDiag(idx)%desc = 'temperature tendency due to micro-physics'
+    ExtDiag(idx)%unit = 'K/s'
+    ExtDiag(idx)%time_avg = .true.
+    ExtDiag(idx)%mod_name = 'gfs_phys'
+    allocate (ExtDiag(idx)%data(nblks))
+    do nb = 1,nblks
+      ExtDiag(idx)%data(nb)%var3 => IntDiag(nb)%t_dt(:,:,6)
+    enddo
+
+    idx = idx + 1
+    ExtDiag(idx)%axes = 3
+    ExtDiag(idx)%name = 't_dt_orogwd'
+    ExtDiag(idx)%desc = 'temperature tendency due to orographic gravity wave drag'
+    ExtDiag(idx)%unit = 'K/s'
+    ExtDiag(idx)%time_avg = .true.
+    ExtDiag(idx)%mod_name = 'gfs_phys'
+    allocate (ExtDiag(idx)%data(nblks))
+    do nb = 1,nblks
+      ExtDiag(idx)%data(nb)%var3 => IntDiag(nb)%t_dt(:,:,7)
+    enddo
+
+    idx = idx + 1
+    ExtDiag(idx)%axes = 3
+    ExtDiag(idx)%name = 'cvm_phys'
+    ExtDiag(idx)%desc = 'moist specific heat of air at constant volume'
+    ExtDiag(idx)%unit = 'J/kg/K'
+    ExtDiag(idx)%time_avg = .true.
+    ExtDiag(idx)%mod_name = 'gfs_phys'
+    allocate (ExtDiag(idx)%data(nblks))
+    do nb = 1,nblks
+      ExtDiag(idx)%data(nb)%var3 => IntDiag(nb)%cvm(:,:)
+    enddo
+
     idx = idx + 1
     ExtDiag(idx)%axes = 3
     ExtDiag(idx)%name = 'du3dt_pbl'

--- a/FV3/gfsphysics/GFS_layer/GFS_diagnostics.F90
+++ b/FV3/gfsphysics/GFS_layer/GFS_diagnostics.F90
@@ -2497,50 +2497,6 @@ module GFS_diagnostics
       ExtDiag(idx)%data(nb)%var3 => IntDiag(nb)%dv3dt(:,:,4)
     enddo
 
-    idx = idx + 1
-    ExtDiag(idx)%axes = 3
-    ExtDiag(idx)%name = 'dq3dt_pbl'
-    ExtDiag(idx)%desc = 'water vapor change due to turbulence scheme'
-    ExtDiag(idx)%unit = 'kg/kg'
-    ExtDiag(idx)%mod_name = 'gfs_phys'
-    allocate (ExtDiag(idx)%data(nblks))
-    do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var3 => IntDiag(nb)%dq3dt(:,:,1)
-    enddo
-
-    idx = idx + 1
-    ExtDiag(idx)%axes = 3
-    ExtDiag(idx)%name = 'dq3dt_deepcnv'
-    ExtDiag(idx)%desc = 'water vapor change due to deep convection'
-    ExtDiag(idx)%unit = 'kg/kg'
-    ExtDiag(idx)%mod_name = 'gfs_phys'
-    allocate (ExtDiag(idx)%data(nblks))
-    do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var3 => IntDiag(nb)%dq3dt(:,:,2)
-    enddo
-
-    idx = idx + 1
-    ExtDiag(idx)%axes = 3
-    ExtDiag(idx)%name = 'dq3dt_shlwcnv'
-    ExtDiag(idx)%desc = 'water vapor change due to shallow convection'
-    ExtDiag(idx)%unit = 'kg/kg'
-    ExtDiag(idx)%mod_name = 'gfs_phys'
-    allocate (ExtDiag(idx)%data(nblks))
-    do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var3 => IntDiag(nb)%dq3dt(:,:,3)
-    enddo
-
-    idx = idx + 1
-    ExtDiag(idx)%axes = 3
-    ExtDiag(idx)%name = 'dq3dt_microphy'
-    ExtDiag(idx)%desc = 'water vapor change due to microphysics'
-    ExtDiag(idx)%unit = 'kg/kg'
-    ExtDiag(idx)%mod_name = 'gfs_phys'
-    allocate (ExtDiag(idx)%data(nblks))
-    do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var3 => IntDiag(nb)%dq3dt(:,:,4)
-    enddo
-
 ! Applying a time_avg converts these qv_dt_* quantities to average tendencies, 
 ! because it amounts to dividing the total increments (what are stored in the
 ! diagnostics buckets) by the total time elapsed for the diagnostics interval

--- a/FV3/gfsphysics/GFS_layer/GFS_diagnostics.F90
+++ b/FV3/gfsphysics/GFS_layer/GFS_diagnostics.F90
@@ -2386,8 +2386,8 @@ module GFS_diagnostics
 
     idx = idx + 1
     ExtDiag(idx)%axes = 3
-    ExtDiag(idx)%name = 'tendency_of_air_temperature_due_to_dissipation_of_orographic_gravity_waves'
-    ExtDiag(idx)%desc = 'temperature tendency due to orographic gravity wave drag'
+    ExtDiag(idx)%name = 'tendency_of_air_temperature_due_to_dissipation_of_gravity_waves'
+    ExtDiag(idx)%desc = 'temperature tendency due to gravity wave drag'
     ExtDiag(idx)%unit = 'K/s'
     ExtDiag(idx)%time_avg = .true.
     ExtDiag(idx)%mod_name = 'gfs_phys'

--- a/FV3/gfsphysics/GFS_layer/GFS_diagnostics.F90
+++ b/FV3/gfsphysics/GFS_layer/GFS_diagnostics.F90
@@ -2308,8 +2308,10 @@ module GFS_diagnostics
       ExtDiag(idx)%data(nb)%var3 => IntDiag(nb)%dt3dt(:,:,7)
     enddo
 
-! Add *time_avg* versions of the existing dt3dt diagnostics; this converts
-! them to tendencies.
+! Applying a time_avg converts these t_dt_* quantities to average tendencies, 
+! because it amounts to dividing the total increments (what are stored in the
+! diagnostics buckets) by the total time elapsed for the diagnostics interval
+! (in seconds).  
     idx = idx + 1
     ExtDiag(idx)%axes = 3
     ExtDiag(idx)%name = 't_dt_lw'
@@ -2539,6 +2541,10 @@ module GFS_diagnostics
       ExtDiag(idx)%data(nb)%var3 => IntDiag(nb)%dq3dt(:,:,4)
     enddo
 
+! Applying a time_avg converts these qv_dt_* quantities to average tendencies, 
+! because it amounts to dividing the total increments (what are stored in the
+! diagnostics buckets) by the total time elapsed for the diagnostics interval
+! (in seconds). 
     idx = idx + 1
     ExtDiag(idx)%axes = 3
     ExtDiag(idx)%name = 'qv_dt_pbl'

--- a/FV3/gfsphysics/GFS_layer/GFS_diagnostics.F90
+++ b/FV3/gfsphysics/GFS_layer/GFS_diagnostics.F90
@@ -2314,7 +2314,7 @@ module GFS_diagnostics
 ! (in seconds).  
     idx = idx + 1
     ExtDiag(idx)%axes = 3
-    ExtDiag(idx)%name = 't_dt_lw'
+    ExtDiag(idx)%name = 'tendency_of_air_temperature_due_to_longwave_heating'
     ExtDiag(idx)%desc = 'temperature tendency due to longwave radiation'
     ExtDiag(idx)%unit = 'K/s'
     ExtDiag(idx)%time_avg = .true.
@@ -2326,7 +2326,7 @@ module GFS_diagnostics
 
     idx = idx + 1
     ExtDiag(idx)%axes = 3
-    ExtDiag(idx)%name = 't_dt_sw'
+    ExtDiag(idx)%name = 'tendency_of_air_temperature_due_to_shortwave_heating'
     ExtDiag(idx)%desc = 'temperature tendency due to shortwave radiation'
     ExtDiag(idx)%unit = 'K/s'
     ExtDiag(idx)%time_avg = .true.
@@ -2338,8 +2338,8 @@ module GFS_diagnostics
 
     idx = idx + 1
     ExtDiag(idx)%axes = 3
-    ExtDiag(idx)%name = 't_dt_pbl'
-    ExtDiag(idx)%desc = 'temperature tendency due to pbl'
+    ExtDiag(idx)%name = 'tendency_of_air_temperature_due_to_turbulence'
+    ExtDiag(idx)%desc = 'temperature tendency due to turbulence scheme'
     ExtDiag(idx)%unit = 'K/s'
     ExtDiag(idx)%time_avg = .true.
     ExtDiag(idx)%mod_name = 'gfs_phys'
@@ -2350,7 +2350,7 @@ module GFS_diagnostics
 
     idx = idx + 1
     ExtDiag(idx)%axes = 3
-    ExtDiag(idx)%name = 't_dt_deepcnv'
+    ExtDiag(idx)%name = 'tendency_of_air_temperature_due_to_deep_convection'
     ExtDiag(idx)%desc = 'temperature tendency due to deep convection'
     ExtDiag(idx)%unit = 'K/s'
     ExtDiag(idx)%time_avg = .true.
@@ -2362,7 +2362,7 @@ module GFS_diagnostics
 
     idx = idx + 1
     ExtDiag(idx)%axes = 3
-    ExtDiag(idx)%name = 't_dt_shlwcnv'
+    ExtDiag(idx)%name = 'tendency_of_air_temperature_due_to_shallow_convection'
     ExtDiag(idx)%desc = 'temperature tendency due to shallow convection'
     ExtDiag(idx)%unit = 'K/s'
     ExtDiag(idx)%time_avg = .true.
@@ -2374,7 +2374,7 @@ module GFS_diagnostics
 
     idx = idx + 1
     ExtDiag(idx)%axes = 3
-    ExtDiag(idx)%name = 't_dt_microphy'
+    ExtDiag(idx)%name = 'tendency_of_air_temperature_due_to_microphysics'
     ExtDiag(idx)%desc = 'temperature tendency due to micro-physics'
     ExtDiag(idx)%unit = 'K/s'
     ExtDiag(idx)%time_avg = .true.
@@ -2386,7 +2386,7 @@ module GFS_diagnostics
 
     idx = idx + 1
     ExtDiag(idx)%axes = 3
-    ExtDiag(idx)%name = 't_dt_orogwd'
+    ExtDiag(idx)%name = 'tendency_of_air_temperature_due_to_dissipation_of_orographic_gravity_waves'
     ExtDiag(idx)%desc = 'temperature tendency due to orographic gravity wave drag'
     ExtDiag(idx)%unit = 'K/s'
     ExtDiag(idx)%time_avg = .true.
@@ -2503,7 +2503,7 @@ module GFS_diagnostics
 ! (in seconds). 
     idx = idx + 1
     ExtDiag(idx)%axes = 3
-    ExtDiag(idx)%name = 'qv_dt_pbl'
+    ExtDiag(idx)%name = 'tendency_of_specific_humidity_due_to_turbulence'
     ExtDiag(idx)%desc = 'water vapor tendency due to turbulence scheme'
     ExtDiag(idx)%unit = 'kg/kg/s'
     ExtDiag(idx)%mod_name = 'gfs_phys'
@@ -2515,7 +2515,7 @@ module GFS_diagnostics
 
     idx = idx + 1
     ExtDiag(idx)%axes = 3
-    ExtDiag(idx)%name = 'qv_dt_deepcnv'
+    ExtDiag(idx)%name = 'tendency_of_specific_humidity_due_to_deep_convection'
     ExtDiag(idx)%desc = 'water vapor tendency due to deep convection'
     ExtDiag(idx)%unit = 'kg/kg/s'
     ExtDiag(idx)%mod_name = 'gfs_phys'
@@ -2527,7 +2527,7 @@ module GFS_diagnostics
 
     idx = idx + 1
     ExtDiag(idx)%axes = 3
-    ExtDiag(idx)%name = 'qv_dt_shlwcnv'
+    ExtDiag(idx)%name = 'tendency_of_specific_humidity_due_to_shallow_convection'
     ExtDiag(idx)%desc = 'water vapor tendency due to shallow convection'
     ExtDiag(idx)%unit = 'kg/kg/s'
     ExtDiag(idx)%mod_name = 'gfs_phys'
@@ -2539,7 +2539,7 @@ module GFS_diagnostics
 
     idx = idx + 1
     ExtDiag(idx)%axes = 3
-    ExtDiag(idx)%name = 'qv_dt_microphy'
+    ExtDiag(idx)%name = 'tendency_of_specific_humidity_due_to_microphysics'
     ExtDiag(idx)%desc = 'water vapor tendency due to microphysics'
     ExtDiag(idx)%unit = 'kg/kg/s'
     ExtDiag(idx)%mod_name = 'gfs_phys'
@@ -2551,7 +2551,7 @@ module GFS_diagnostics
 
     idx = idx + 1
     ExtDiag(idx)%axes = 3
-    ExtDiag(idx)%name = 'qv_dt_residual'
+    ExtDiag(idx)%name = 'tendency_of_specific_humidity_due_to_change_in_atmosphere_mass'
     ExtDiag(idx)%desc = 'residual water vapor tendency'
     ExtDiag(idx)%unit = 'kg/kg/s'
     ExtDiag(idx)%mod_name = 'gfs_phys'

--- a/FV3/gfsphysics/GFS_layer/GFS_diagnostics.F90
+++ b/FV3/gfsphysics/GFS_layer/GFS_diagnostics.F90
@@ -2398,18 +2398,6 @@ module GFS_diagnostics
 
     idx = idx + 1
     ExtDiag(idx)%axes = 3
-    ExtDiag(idx)%name = 'c_phys'
-    ExtDiag(idx)%desc = 'moist specific heat of air at constant volume (if non-hydrostatic dycore) or constant pressure (if hydrostatic dycore)'
-    ExtDiag(idx)%unit = 'J/kg/K'
-    ExtDiag(idx)%time_avg = .true.
-    ExtDiag(idx)%mod_name = 'gfs_phys'
-    allocate (ExtDiag(idx)%data(nblks))
-    do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var3 => IntDiag(nb)%specific_heat(:,:)
-    enddo
-
-    idx = idx + 1
-    ExtDiag(idx)%axes = 3
     ExtDiag(idx)%name = 'du3dt_pbl'
     ExtDiag(idx)%desc = 'u momentum change due to PBL'
     ExtDiag(idx)%unit = 'XXX'

--- a/FV3/gfsphysics/GFS_layer/GFS_diagnostics.F90
+++ b/FV3/gfsphysics/GFS_layer/GFS_diagnostics.F90
@@ -2587,6 +2587,18 @@ module GFS_diagnostics
       ExtDiag(idx)%data(nb)%var3 => IntDiag(nb)%q_dt(:,:,4)
     enddo
 
+    idx = idx + 1
+    ExtDiag(idx)%axes = 3
+    ExtDiag(idx)%name = 'qv_dt_residual'
+    ExtDiag(idx)%desc = 'residual water vapor tendency'
+    ExtDiag(idx)%unit = 'kg/kg/s'
+    ExtDiag(idx)%mod_name = 'gfs_phys'
+    ExtDiag(idx)%time_avg = .true.
+    allocate (ExtDiag(idx)%data(nblks))
+    do nb = 1,nblks
+      ExtDiag(idx)%data(nb)%var3 => IntDiag(nb)%q_dt(:,:,5)
+    enddo
+
 !rab
 !rab    do num = 1,5+Mdl_parms%pl_coeff
 !rab      write (xtra,'(I1)') num 

--- a/FV3/gfsphysics/GFS_layer/GFS_physics_driver.F90
+++ b/FV3/gfsphysics/GFS_layer/GFS_physics_driver.F90
@@ -5553,11 +5553,14 @@ module module_physics_driver
         real(kind=kind_phys) :: cv_air = con_cp - con_rd  ! From fv_mapz.F90
         real(kind=kind_phys) :: cv_vap = 3.0 * con_rv  ! From fv_mapz.F90
         real(kind=kind_phys) :: c_liq = 4.1885e3  ! Hard-coded in fv_mapz.F90
-        real(kind=kind_phys) :: c_ice = 1972.0  ! Hard-coded fv_mapz.F90
+        real(kind=kind_phys) :: c_ice = 1972.0  ! Hard-coded in fv_mapz.F90
         integer :: tracer_indexes(6)
 
         tracer_indexes = (/ ntqv, ntcw, ntiw, ntrw, ntsw, ntgl /)
 
+        ! fv_mapz.moist_cv defines branches for using other moist tracer configurations.  For simplicity
+        ! we choose not to replicate that behavior here, since we have only run in one tracer configuration
+        ! so far.
 #ifdef MULTI_GASES
         call mpp_error (NOTE, 'GFS_physics_driver::moist_cv - moist_cv for tracer configuration not implemented; using default cv_air for t_dt diagnostics')
         cvm = cv_air

--- a/FV3/gfsphysics/GFS_layer/GFS_physics_driver.F90
+++ b/FV3/gfsphysics/GFS_layer/GFS_physics_driver.F90
@@ -5358,7 +5358,6 @@ module module_physics_driver
               Statein%prsi(1:im,1:levs+1), im, levs, nwat, 1, Model%ntcw, Model%ntiw, &
               Model%ntrw, Model%ntsw, Model%ntgl, specific_heat)
         endif
-        Diag%specific_heat(:,:) = Diag%specific_heat(:,:) + dtf * specific_heat(:,:)
 
         call update_temperature_tendency_diagnostics(Diag%t_dt, dt3dt_initial, Diag%dt3dt, &
             specific_heat, im, levs)

--- a/FV3/gfsphysics/GFS_layer/GFS_physics_driver.F90
+++ b/FV3/gfsphysics/GFS_layer/GFS_physics_driver.F90
@@ -5584,7 +5584,7 @@ module module_physics_driver
 
         real(kind=kind_phys) :: cv_air = con_cp - con_rd  ! From fv_mapz.F90
         real(kind=kind_phys) :: cv_vap = 3.0 * con_rv  ! From fv_mapz.F90
-        real(kind=kind_phys) :: c_liq = 4.1885e3  ! Hard-coded in fv_mapz.F90
+        real(kind=kind_phys) :: c_liq = 4.1855e3  ! Hard-coded in fv_mapz.F90
         real(kind=kind_phys) :: c_ice = 1972.0  ! Hard-coded in fv_mapz.F90
         integer :: tracer_indexes(6)
 

--- a/FV3/gfsphysics/GFS_layer/GFS_physics_driver.F90
+++ b/FV3/gfsphysics/GFS_layer/GFS_physics_driver.F90
@@ -3499,14 +3499,6 @@ module module_physics_driver
 !  --- ...  calling convective parameterization
 !           -----------------------------------
       if (Model%do_deep) then
-
-        if (Model%ldiag3d) then
-          do i = 1, im
-            do k = 1, levs
-              dqdt_work(i,k) = Stateout%gq0(i,k,1)
-            enddo
-          enddo
-        endif
  
         if (Model%do_ca) then
           do k=1,levs
@@ -3810,7 +3802,7 @@ module module_physics_driver
           do k=1,levs
             do i=1,im
               Diag%dt3dt(i,k,4) = Diag%dt3dt(i,k,4) + (Stateout%gt0(i,k)-dtdt(i,k)) * frain
-              Diag%dq3dt(i,k,2) = Diag%dq3dt(i,k,2) + (Stateout%gq0(i,k,1)-dqdt_work(i,k)) * frain
+              Diag%dq3dt(i,k,2) = Diag%dq3dt(i,k,2) + (Stateout%gq0(i,k,1)-dqdt(i,k,1)) * frain
               Diag%du3dt(i,k,3) = Diag%du3dt(i,k,3) + (Stateout%gu0(i,k)-dudt(i,k)) * frain
               Diag%dv3dt(i,k,3) = Diag%dv3dt(i,k,3) + (Stateout%gv0(i,k)-dvdt(i,k)) * frain
 !             Diag%upd_mf(i,k)  = Diag%upd_mf(i,k)  + ud_mf(i,k) * (con_g*frain)
@@ -4051,6 +4043,7 @@ module module_physics_driver
         do k=1,levs
           do i=1,im
             dtdt(i,k)   = Stateout%gt0(i,k)
+            dqdt_work(i,k) = Stateout%gq0(i,k,1)
           enddo
         enddo
       endif
@@ -4059,13 +4052,6 @@ module module_physics_driver
 
         if (Model%shal_cnv) then               ! Shallow convection parameterizations
 !                                               --------------------------------------
-          if (Model%ldiag3d) then
-            do k=1,levs
-              do i=1,im
-                dqdt_work(i,k) = Stateout%gq0(i,k,1)
-              enddo
-            enddo
-          endif
           if (Model%imfshalcnv == 1) then      ! opr option now at 2014
                                                !-----------------------
             call shalcnv (im, ix, levs, Model%jcap, dtp, del, Statein%prsl, &

--- a/FV3/gfsphysics/GFS_layer/GFS_physics_driver.F90
+++ b/FV3/gfsphysics/GFS_layer/GFS_physics_driver.F90
@@ -2777,6 +2777,7 @@ module module_physics_driver
               do i=1,im
                 tem  = dtdt(i,k) - (Radtend%htrlw(i,k)+Radtend%htrsw(i,k)*xmu(i))
                 Diag%dt3dt(i,k,3) = Diag%dt3dt(i,k,3) + tem*dtf
+                Diag%dq3dt(i,k,1) = Diag%dq3dt(i,k,1) + dqdt(i,k,1) * dtp
               enddo
             enddo
           endif
@@ -3790,7 +3791,7 @@ module module_physics_driver
           do k=1,levs
             do i=1,im
               Diag%dt3dt(i,k,4) = Diag%dt3dt(i,k,4) + (Stateout%gt0(i,k)-dtdt(i,k)) * frain
-!             Diag%dq3dt(i,k,2) = Diag%dq3dt(i,k,2) + (Stateout%gq0(i,k,1)-dqdt(i,k,1)) * frain
+              Diag%dq3dt(i,k,2) = Diag%dq3dt(i,k,2) + (Stateout%gq0(i,k,1)-dqdt(i,k,1)) * frain
               Diag%du3dt(i,k,3) = Diag%du3dt(i,k,3) + (Stateout%gu0(i,k)-dudt(i,k)) * frain
               Diag%dv3dt(i,k,3) = Diag%dv3dt(i,k,3) + (Stateout%gv0(i,k)-dvdt(i,k)) * frain
 !             Diag%upd_mf(i,k)  = Diag%upd_mf(i,k)  + ud_mf(i,k) * (con_g*frain)
@@ -4146,7 +4147,7 @@ module module_physics_driver
             do k=1,levs
               do i=1,im
                 Diag%dt3dt(i,k,5) = Diag%dt3dt(i,k,5) + (Stateout%gt0(i,k)  -dtdt(i,k))   * frain
-!               Diag%dq3dt(i,k,3) = Diag%dq3dt(i,k,3) + (Stateout%gq0(i,k,1)-dqdt(i,k,1)) * frain
+                Diag%dq3dt(i,k,3) = Diag%dq3dt(i,k,3) + (Stateout%gq0(i,k,1)-dqdt(i,k,1)) * frain
               enddo
             enddo
           endif
@@ -5057,7 +5058,7 @@ module module_physics_driver
           do k=1,levs
             do i=1,im
               Diag%dt3dt(i,k,6) = Diag%dt3dt(i,k,6) + (Stateout%gt0(i,k)-dtdt(i,k)) * frain
-!             Diag%dq3dt(i,k,4) = Diag%dq3dt(i,k,4) + (Stateout%gq0(i,k,1)-dqdt(i,k,1)) * frain
+              Diag%dq3dt(i,k,4) = Diag%dq3dt(i,k,4) + (Stateout%gq0(i,k,1)-dqdt(i,k,1)) * frain
             enddo
           enddo
         endif
@@ -5339,6 +5340,9 @@ module module_physics_driver
               Model%ntrw, Model%ntsw, Model%ntgl, cvm)
         do i = 1, size(Diag%t_dt, 3)
           Diag%t_dt(:,:,i) = con_cp * Diag%dt3dt(:,:,i) / cvm(:,:)
+        enddo
+        do i = 1, size(Diag%q_dt, 3)
+          Diag%q_dt(:,:,i) = Diag%dq3dt(:,:,i)  ! TODO: adjust these
         enddo
         Diag%cvm(:,:) = Diag%cvm(:,:) + dtf * cvm(:,:)
       endif

--- a/FV3/gfsphysics/GFS_layer/GFS_physics_driver.F90
+++ b/FV3/gfsphysics/GFS_layer/GFS_physics_driver.F90
@@ -5339,10 +5339,10 @@ module module_physics_driver
               Statein%prsi(1:im,1:levs+1), im, levs, 6, 1, Model%ntcw, Model%ntiw, &
               Model%ntrw, Model%ntsw, Model%ntgl, cvm)
         do i = 1, size(Diag%t_dt, 3)
-          Diag%t_dt(:,:,i) = con_cp * Diag%dt3dt(:,:,i) / cvm(:,:)
+          Diag%t_dt(:,:,i) = Diag%t_dt(:,:,i) + con_cp * Diag%dt3dt(:,:,i) / cvm(:,:)
         enddo
         do i = 1, size(Diag%q_dt, 3)
-          Diag%q_dt(:,:,i) = Diag%dq3dt(:,:,i)  ! TODO: adjust these
+          Diag%q_dt(:,:,i) = Diag%q_dt(:,:,i) + Diag%dq3dt(:,:,i)  ! TODO: adjust these
         enddo
         Diag%cvm(:,:) = Diag%cvm(:,:) + dtf * cvm(:,:)
       endif

--- a/FV3/gfsphysics/GFS_layer/GFS_physics_driver.F90
+++ b/FV3/gfsphysics/GFS_layer/GFS_physics_driver.F90
@@ -5677,7 +5677,8 @@ module module_physics_driver
       end subroutine update_temperature_tendency_diagnostics
 
       ! Scale the water vapor mass fraction increment for each physics component by
-      ! (mass of dry air + mass of only water vapor) / (mass of dry air + mass of all hydrometeors).
+      ! (mass of dry air + mass of only water vapor at the start of the physics) / 
+      ! (mass of dry air + mass of all hydrometeors at the end of the physics).
       !
       ! This leaves a residual water vapor tendency that cannot be assigned to a single
       ! physical process (because the mass of dry air + mass of all hydrometeors changes

--- a/FV3/gfsphysics/GFS_layer/GFS_typedefs.F90
+++ b/FV3/gfsphysics/GFS_layer/GFS_typedefs.F90
@@ -5119,7 +5119,7 @@ module GFS_typedefs
       allocate (Diag%t_dt   (IM,Model%levs,7))
       allocate (Diag%cvm    (IM,Model%levs))
       allocate (Diag%dq3dt  (IM,Model%levs,9))
-      allocate (Diag%q_dt   (IM,Model%levs,4))
+      allocate (Diag%q_dt   (IM,Model%levs,5))
 !      allocate (Diag%dq3dt  (IM,Model%levs,oz_coeff+5))
 !--- needed to allocate GoCart coupling fields
 !      allocate (Diag%upd_mf (IM,Model%levs))

--- a/FV3/gfsphysics/GFS_layer/GFS_typedefs.F90
+++ b/FV3/gfsphysics/GFS_layer/GFS_typedefs.F90
@@ -187,6 +187,7 @@ module GFS_typedefs
     real (kind=kind_phys), pointer :: atm_ts (:)  => null() !< surface temperature from dynamical core
  
     logical, pointer :: dycore_hydrostatic        => null()  !< whether the dynamical core is hydrostatic
+    integer, pointer :: nwat                      => null()  !< number of water species used in the model
     contains
       procedure :: create  => statein_create  !<   allocate array data
   end type GFS_statein_type
@@ -2001,6 +2002,9 @@ module GFS_typedefs
 
     allocate(Statein%dycore_hydrostatic)
     Statein%dycore_hydrostatic = .true.
+
+    allocate(Statein%nwat)
+    Statein%nwat = 6
   end subroutine statein_create
 
 

--- a/FV3/gfsphysics/GFS_layer/GFS_typedefs.F90
+++ b/FV3/gfsphysics/GFS_layer/GFS_typedefs.F90
@@ -186,7 +186,7 @@ module GFS_typedefs
     real (kind=kind_phys), pointer :: slc (:,:)   => null()  !< soil liquid water content
     real (kind=kind_phys), pointer :: atm_ts (:)  => null() !< surface temperature from dynamical core
  
-    logical, pointer :: dycore_hydrostatic        => null()  !< whether the dynamical core is hydrostatic
+    logical :: dycore_hydrostatic                            !< whether the dynamical core is hydrostatic
     contains
       procedure :: create  => statein_create  !<   allocate array data
   end type GFS_statein_type
@@ -1999,7 +1999,6 @@ module GFS_typedefs
     ! surface temperature from atmospheric prognostic state
     allocate (Statein%atm_ts(IM))
     Statein%atm_ts = clear_val
-    Statein%dycore_hydrostatic = .true.
 
   end subroutine statein_create
 

--- a/FV3/gfsphysics/GFS_layer/GFS_typedefs.F90
+++ b/FV3/gfsphysics/GFS_layer/GFS_typedefs.F90
@@ -1457,6 +1457,8 @@ module GFS_typedefs
     real (kind=kind_phys), pointer :: du3dt (:,:,:)  => null()   !< u momentum change due to physics
     real (kind=kind_phys), pointer :: dv3dt (:,:,:)  => null()   !< v momentum change due to physics
     real (kind=kind_phys), pointer :: dt3dt (:,:,:)  => null()   !< temperature change due to physics
+    real (kind=kind_phys), pointer :: t_dt(:,:,:)    => null()   !< temperature change due to physics scaled by cp / cvm
+    real (kind=kind_phys), pointer :: cvm(:,:)       => null()      !< moist specific heat of air at constant volume
     real (kind=kind_phys), pointer :: dq3dt (:,:,:)  => null()   !< moisture change due to physics
     real (kind=kind_phys), pointer :: refdmax (:)    => null()   !< max hourly 1-km agl reflectivity
     real (kind=kind_phys), pointer :: refdmax263k(:) => null()   !< max hourly -10C reflectivity
@@ -5113,6 +5115,8 @@ module GFS_typedefs
       allocate (Diag%du3dt  (IM,Model%levs,4))
       allocate (Diag%dv3dt  (IM,Model%levs,4))
       allocate (Diag%dt3dt  (IM,Model%levs,7))
+      allocate (Diag%t_dt   (IM,Model%levs,7))
+      allocate (Diag%cvm    (IM,Model%levs))
       allocate (Diag%dq3dt  (IM,Model%levs,9))
 !      allocate (Diag%dq3dt  (IM,Model%levs,oz_coeff+5))
 !--- needed to allocate GoCart coupling fields
@@ -5413,6 +5417,8 @@ module GFS_typedefs
       Diag%du3dt    = zero
       Diag%dv3dt    = zero
       Diag%dt3dt    = zero
+      Diag%t_dt     = zero
+      Diag%cvm      = zero
 !     Diag%dq3dt    = zero
 !     Diag%upd_mf   = zero
 !     Diag%dwn_mf   = zero

--- a/FV3/gfsphysics/GFS_layer/GFS_typedefs.F90
+++ b/FV3/gfsphysics/GFS_layer/GFS_typedefs.F90
@@ -1458,7 +1458,7 @@ module GFS_typedefs
     real (kind=kind_phys), pointer :: dv3dt (:,:,:)  => null()   !< v momentum change due to physics
     real (kind=kind_phys), pointer :: dt3dt (:,:,:)  => null()   !< temperature change due to physics
     real (kind=kind_phys), pointer :: t_dt(:,:,:)    => null()   !< temperature change due to physics scaled by cp / cvm
-    real (kind=kind_phys), pointer :: cvm(:,:)       => null()      !< moist specific heat of air at constant volume
+    real (kind=kind_phys), pointer :: cvm(:,:)       => null()   !< moist specific heat of air at constant volume
     real (kind=kind_phys), pointer :: dq3dt (:,:,:)  => null()   !< moisture change due to physics
     real (kind=kind_phys), pointer :: q_dt  (:,:,:)  => null()   !< moisture tendency due to physics, adjusted to dycore mass fraction convention
     real (kind=kind_phys), pointer :: refdmax (:)    => null()   !< max hourly 1-km agl reflectivity

--- a/FV3/gfsphysics/GFS_layer/GFS_typedefs.F90
+++ b/FV3/gfsphysics/GFS_layer/GFS_typedefs.F90
@@ -186,7 +186,7 @@ module GFS_typedefs
     real (kind=kind_phys), pointer :: slc (:,:)   => null()  !< soil liquid water content
     real (kind=kind_phys), pointer :: atm_ts (:)  => null() !< surface temperature from dynamical core
  
-    logical :: dycore_hydrostatic                            !< whether the dynamical core is hydrostatic
+    logical, pointer :: dycore_hydrostatic        => null()  !< whether the dynamical core is hydrostatic
     contains
       procedure :: create  => statein_create  !<   allocate array data
   end type GFS_statein_type
@@ -2000,6 +2000,8 @@ module GFS_typedefs
     allocate (Statein%atm_ts(IM))
     Statein%atm_ts = clear_val
 
+    allocate(Statein%dycore_hydrostatic)
+    Statein%dycore_hydrostatic = .true.
   end subroutine statein_create
 
 

--- a/FV3/gfsphysics/GFS_layer/GFS_typedefs.F90
+++ b/FV3/gfsphysics/GFS_layer/GFS_typedefs.F90
@@ -1459,7 +1459,6 @@ module GFS_typedefs
     real (kind=kind_phys), pointer :: dv3dt (:,:,:)  => null()   !< v momentum change due to physics
     real (kind=kind_phys), pointer :: dt3dt (:,:,:)  => null()   !< temperature change due to physics
     real (kind=kind_phys), pointer :: t_dt(:,:,:)    => null()   !< temperature change due to physics scaled by cp / cvm or cp / cpm
-    real (kind=kind_phys), pointer :: specific_heat(:,:) => null()   !< moist specific heat of air for scaling temperature tendency diagnostics (cvm or cpm)
     real (kind=kind_phys), pointer :: dq3dt (:,:,:)  => null()   !< moisture change due to physics
     real (kind=kind_phys), pointer :: q_dt  (:,:,:)  => null()   !< moisture tendency due to physics, adjusted to dycore mass fraction convention
     real (kind=kind_phys), pointer :: refdmax (:)    => null()   !< max hourly 1-km agl reflectivity
@@ -5120,7 +5119,6 @@ module GFS_typedefs
       allocate (Diag%dv3dt  (IM,Model%levs,4))
       allocate (Diag%dt3dt  (IM,Model%levs,7))
       allocate (Diag%t_dt   (IM,Model%levs,7))
-      allocate (Diag%specific_heat (IM,Model%levs))
       allocate (Diag%dq3dt  (IM,Model%levs,9))
       allocate (Diag%q_dt   (IM,Model%levs,5))
 !      allocate (Diag%dq3dt  (IM,Model%levs,oz_coeff+5))
@@ -5423,7 +5421,6 @@ module GFS_typedefs
       Diag%dv3dt    = zero
       Diag%dt3dt    = zero
       Diag%t_dt     = zero
-      Diag%specific_heat = zero
       Diag%dq3dt    = zero
       Diag%q_dt     = zero
 !     Diag%upd_mf   = zero

--- a/FV3/gfsphysics/GFS_layer/GFS_typedefs.F90
+++ b/FV3/gfsphysics/GFS_layer/GFS_typedefs.F90
@@ -1471,7 +1471,7 @@ module GFS_typedefs
     real (kind=kind_phys), pointer :: upd_mf (:,:)   => null()  !< instantaneous convective updraft mass flux
     real (kind=kind_phys), pointer :: dwn_mf (:,:)   => null()  !< instantaneous convective downdraft mass flux
     real (kind=kind_phys), pointer :: det_mf (:,:)   => null()  !< instantaneous convective detrainment mass flux
-    real (kind=kind_phys), pointer :: cldcov (:,:)   => null()  !< instantaneous 3D cloud fraction
+!   real (kind=kind_phys), pointer :: cldcov (:,:)   => null()  !< instantaneous 3D cloud fraction
 
     !--- MP quantities for 3D diagnositics 
     real (kind=kind_phys), pointer :: refl_10cm(:,:) => null()  !< instantaneous refl_10cm 
@@ -5125,7 +5125,7 @@ module GFS_typedefs
 !      allocate (Diag%upd_mf (IM,Model%levs))
 !      allocate (Diag%dwn_mf (IM,Model%levs))
 !      allocate (Diag%det_mf (IM,Model%levs))
-      allocate (Diag%cldcov (IM,Model%levs))
+!      allocate (Diag%cldcov (IM,Model%levs))
     endif
 
 !vay-2018
@@ -5302,9 +5302,9 @@ module GFS_typedefs
     Diag%topfsw%upfx0 = zero
     Diag%topflw%upfxc = zero
     Diag%topflw%upfx0 = zero
-    if (Model%ldiag3d) then
-      Diag%cldcov     = zero
-    endif
+    ! if (Model%ldiag3d) then
+    !   Diag%cldcov     = zero
+    ! endif
 
   end subroutine diag_rad_zero
 

--- a/FV3/gfsphysics/GFS_layer/GFS_typedefs.F90
+++ b/FV3/gfsphysics/GFS_layer/GFS_typedefs.F90
@@ -1460,6 +1460,7 @@ module GFS_typedefs
     real (kind=kind_phys), pointer :: t_dt(:,:,:)    => null()   !< temperature change due to physics scaled by cp / cvm
     real (kind=kind_phys), pointer :: cvm(:,:)       => null()      !< moist specific heat of air at constant volume
     real (kind=kind_phys), pointer :: dq3dt (:,:,:)  => null()   !< moisture change due to physics
+    real (kind=kind_phys), pointer :: q_dt  (:,:,:)  => null()   !< moisture tendency due to physics, adjusted to dycore mass fraction convention
     real (kind=kind_phys), pointer :: refdmax (:)    => null()   !< max hourly 1-km agl reflectivity
     real (kind=kind_phys), pointer :: refdmax263k(:) => null()   !< max hourly -10C reflectivity
     real (kind=kind_phys), pointer :: t02max  (:)    => null()   !< max hourly 2m T
@@ -5118,6 +5119,7 @@ module GFS_typedefs
       allocate (Diag%t_dt   (IM,Model%levs,7))
       allocate (Diag%cvm    (IM,Model%levs))
       allocate (Diag%dq3dt  (IM,Model%levs,9))
+      allocate (Diag%q_dt   (IM,Model%levs,4))
 !      allocate (Diag%dq3dt  (IM,Model%levs,oz_coeff+5))
 !--- needed to allocate GoCart coupling fields
 !      allocate (Diag%upd_mf (IM,Model%levs))
@@ -5419,7 +5421,8 @@ module GFS_typedefs
       Diag%dt3dt    = zero
       Diag%t_dt     = zero
       Diag%cvm      = zero
-!     Diag%dq3dt    = zero
+      Diag%dq3dt    = zero
+      Diag%q_dt     = zero
 !     Diag%upd_mf   = zero
 !     Diag%dwn_mf   = zero
 !     Diag%det_mf   = zero

--- a/FV3/gfsphysics/GFS_layer/GFS_typedefs.F90
+++ b/FV3/gfsphysics/GFS_layer/GFS_typedefs.F90
@@ -5119,7 +5119,7 @@ module GFS_typedefs
 !      allocate (Diag%upd_mf (IM,Model%levs))
 !      allocate (Diag%dwn_mf (IM,Model%levs))
 !      allocate (Diag%det_mf (IM,Model%levs))
-!      allocate (Diag%cldcov (IM,Model%levs))
+      allocate (Diag%cldcov (IM,Model%levs))
     endif
 
 !vay-2018

--- a/FV3/gfsphysics/physics/GFS_debug.F90
+++ b/FV3/gfsphysics/physics/GFS_debug.F90
@@ -331,7 +331,7 @@
                        call print_var(mpirank,omprank, blkno, 'Diag%upd_mf      ',    Diag%upd_mf)
                        call print_var(mpirank,omprank, blkno, 'Diag%dwn_mf      ',    Diag%dwn_mf)
                        call print_var(mpirank,omprank, blkno, 'Diag%det_mf      ',    Diag%det_mf)
-                       call print_var(mpirank,omprank, blkno, 'Diag%cldcov      ',    Diag%cldcov)
+                    !  call print_var(mpirank,omprank, blkno, 'Diag%cldcov      ',    Diag%cldcov)
                      end if
                      if(Model%lradar) then
                        call print_var(mpirank,omprank, blkno, 'Diag%refl_10cm   ',  Diag%refl_10cm)


### PR DESCRIPTION
This PR adds a number of diagnostics to the fortran model, with the aim of making it possible to diagnose the tendencies of temperature and water vapor as contributed by each component of the physics.

**For verification purposes and convenience, it introduces two new dynamical core diagnostics:**

- `t_dt_phys`, which captures the total tendency of temperature in the dynamical core contributed by all physics routines.
- `qv_dt_phys`, which captures the total tendency of specific humidity in the dynamical core contributed by all physics routines.

*Note that both of these new dynamical core diagnostics do not include tendencies due to saturation adjustment performed within the dynamical core, or nudging to analysis.  This is consistent with how they are defined in SHiELD.*

**In addition, the following physics diagnostics are introduced:**

Temperature tendency diagnostics.  Note these are scaled by a factor of `cp / cvm`; this ensures that their sum matches the value of `t_dt_phys` as computed within the dynamical core.
- `tendency_of_air_temperature_due_to_longwave_heating`
- `tendency_of_air_temperature_due_to_shortwave_heating`
- `tendency_of_air_temperature_due_to_turbulence`
- `tendency_of_air_temperature_due_to_deep_convection`
- `tendency_of_air_temperature_due_to_shallow_convection`
- `tendency_of_air_temperature_due_to_microphysics`
- `tendency_of_air_temperature_due_to_dissipation_of_orographic_gravity_waves`

Specific humidity tendency diagnostics.  Note that these are converted to use the mass fraction convention of the dynamical core instead of the physics; this ensures that their sum, plus a small residual, matches the value of `qv_dt_phys` as computed within the dynamical core.
- `tendency_of_specific_humidity_due_to_turbulence`
- `tendency_of_specific_humidity_due_to_deep_convection`
- `tendency_of_specific_humidity_due_to_shallow_convection`
- `tendency_of_specific_humidity_due_to_microphysics`
- `tendency_of_specific_humidity_due_to_change_in_atmosphere_mass`, the residual specific humidity tendency (due to changing mass fraction denominator).

**Implementation details**

FV3GFS includes some infrastructure for computing these diagnostics already, which we leverage where possible.  We only make changes where we've diagnosed bugs; otherwise we add new code.

- The `dt3dt` diagnostics bucket records temperature increments applied by each physics routine.  These appear to work as expected; to be converted to `tendency_of_air_temperature_*` diagnostics, they need only be scaled by `cp / cvm` and time-averaged over a diagnostics interval to be converted from temperature increments to time tendencies.
- The first four slices of the `dq3dt` diagnostics bucket records the mass fraction increments of water vapor applied by each relevant physics routine.  Code related to it was largely commented out in FV3GFS, and upon uncommenting, a bug was revealed in computing the increment due to shallow convection: it included the deep convection increment as well.  This bug was fixed by adding another checkpoint to record the water vapor mass fraction just before the shallow convection was called.  These mass fraction increments follow the physics convention; i.e. the denominator is the total mass of dry air plus water vapor.  Therefore, to convert to `tendency_of_specific_humidity_*` diagnostics we scale the water vapor mass fraction increment for each physics component by `(mass of dry air + mass of only water vapor at the start of the physics) / (mass of dry air + mass of all hydrometeors at the end of the physics)`.

**Verification**

To verify that these per-physics component tendency diagnostics are working properly, we verify that their sum matches the bulk physics tendency computed within the dynamical core.  Root mean square error for a single timestep in a C12 simulation is on the order of 10^-10 K/s for the temperature tendency and 10^-15 kg/kg/s for the specific humidity tendency (see [this notebook](https://github.com/VulcanClimateModeling/explore/blob/master/spencerc/2020-08-10-fv3gfs-diagnostics/2020-08-10-fv3gfs-diagnostics.ipynb)).

<p align="center">
  <img src="https://user-images.githubusercontent.com/6628425/90401656-452eb480-e06c-11ea-82df-af5be01cb7ed.png" />
</p>

To get a sense for whether the global mean profiles looked reasonable for each physics component, we ran a 2-day C48 simulation.  These plots show the global time mean over the last day of this run for each physics component (see [this notebook](https://github.com/VulcanClimateModeling/explore/blob/master/spencerc/2020-08-10-fv3gfs-diagnostics/2020-08-17-C48-fv3gfs-diagnostics.ipynb)).

<p align="center">
  <img src="https://user-images.githubusercontent.com/6628425/90417701-1f140f00-e082-11ea-9614-ac5a23811452.png" />
</p>

<p align="center">
  <img src="https://user-images.githubusercontent.com/6628425/90417750-2affd100-e082-11ea-81fc-d34dc42c8ac3.png" />
</p>


Resolves #38 