### PR TITLE
Convert per-physics-component tendency diagnostics from time average to instantaneous

### DIFF
--- a/FV3/gfsphysics/GFS_layer/GFS_diagnostics.F90
+++ b/FV3/gfsphysics/GFS_layer/GFS_diagnostics.F90
@@ -2337,9 +2337,8 @@ module GFS_diagnostics
     idx = idx + 1
     ExtDiag(idx)%axes = 3
     ExtDiag(idx)%name = 'tendency_of_air_temperature_due_to_longwave_heating'
-    ExtDiag(idx)%desc = 'temperature tendency due to longwave radiation'
+    ExtDiag(idx)%desc = 'isntantaneous temperature tendency due to longwave radiation'
     ExtDiag(idx)%unit = 'K/s'
-    ExtDiag(idx)%time_avg = .true.
     ExtDiag(idx)%mod_name = 'gfs_phys'
     allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
@@ -2349,9 +2348,8 @@ module GFS_diagnostics
     idx = idx + 1
     ExtDiag(idx)%axes = 3
     ExtDiag(idx)%name = 'tendency_of_air_temperature_due_to_shortwave_heating'
-    ExtDiag(idx)%desc = 'temperature tendency due to shortwave radiation'
+    ExtDiag(idx)%desc = 'isntantaneous temperature tendency due to shortwave radiation'
     ExtDiag(idx)%unit = 'K/s'
-    ExtDiag(idx)%time_avg = .true.
     ExtDiag(idx)%mod_name = 'gfs_phys'
     allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
@@ -2361,9 +2359,8 @@ module GFS_diagnostics
     idx = idx + 1
     ExtDiag(idx)%axes = 3
     ExtDiag(idx)%name = 'tendency_of_air_temperature_due_to_turbulence'
-    ExtDiag(idx)%desc = 'temperature tendency due to turbulence scheme'
+    ExtDiag(idx)%desc = 'isntantaneous temperature tendency due to turbulence scheme'
     ExtDiag(idx)%unit = 'K/s'
-    ExtDiag(idx)%time_avg = .true.
     ExtDiag(idx)%mod_name = 'gfs_phys'
     allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
@@ -2373,9 +2370,8 @@ module GFS_diagnostics
     idx = idx + 1
     ExtDiag(idx)%axes = 3
     ExtDiag(idx)%name = 'tendency_of_air_temperature_due_to_deep_convection'
-    ExtDiag(idx)%desc = 'temperature tendency due to deep convection'
+    ExtDiag(idx)%desc = 'isntantaneous temperature tendency due to deep convection'
     ExtDiag(idx)%unit = 'K/s'
-    ExtDiag(idx)%time_avg = .true.
     ExtDiag(idx)%mod_name = 'gfs_phys'
     allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
@@ -2385,9 +2381,8 @@ module GFS_diagnostics
     idx = idx + 1
     ExtDiag(idx)%axes = 3
     ExtDiag(idx)%name = 'tendency_of_air_temperature_due_to_shallow_convection'
-    ExtDiag(idx)%desc = 'temperature tendency due to shallow convection'
+    ExtDiag(idx)%desc = 'isntantaneous temperature tendency due to shallow convection'
     ExtDiag(idx)%unit = 'K/s'
-    ExtDiag(idx)%time_avg = .true.
     ExtDiag(idx)%mod_name = 'gfs_phys'
     allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
@@ -2397,9 +2392,8 @@ module GFS_diagnostics
     idx = idx + 1
     ExtDiag(idx)%axes = 3
     ExtDiag(idx)%name = 'tendency_of_air_temperature_due_to_microphysics'
-    ExtDiag(idx)%desc = 'temperature tendency due to micro-physics'
+    ExtDiag(idx)%desc = 'isntantaneous temperature tendency due to micro-physics'
     ExtDiag(idx)%unit = 'K/s'
-    ExtDiag(idx)%time_avg = .true.
     ExtDiag(idx)%mod_name = 'gfs_phys'
     allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
@@ -2409,9 +2403,8 @@ module GFS_diagnostics
     idx = idx + 1
     ExtDiag(idx)%axes = 3
     ExtDiag(idx)%name = 'tendency_of_air_temperature_due_to_dissipation_of_gravity_waves'
-    ExtDiag(idx)%desc = 'temperature tendency due to gravity wave drag'
+    ExtDiag(idx)%desc = 'isntantaneous temperature tendency due to gravity wave drag'
     ExtDiag(idx)%unit = 'K/s'
-    ExtDiag(idx)%time_avg = .true.
     ExtDiag(idx)%mod_name = 'gfs_phys'
     allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
@@ -2421,9 +2414,8 @@ module GFS_diagnostics
     idx = idx + 1
     ExtDiag(idx)%axes = 3
     ExtDiag(idx)%name = 'tendency_of_air_temperature_due_to_longwave_heating_assuming_clear_sky'
-    ExtDiag(idx)%desc = 'temperature tendency due to clear sky longwave radiation'
+    ExtDiag(idx)%desc = 'isntantaneous temperature tendency due to clear sky longwave radiation'
     ExtDiag(idx)%unit = 'K/s'
-    ExtDiag(idx)%time_avg = .true.
     ExtDiag(idx)%mod_name = 'gfs_phys'
     allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
@@ -2433,9 +2425,8 @@ module GFS_diagnostics
     idx = idx + 1
     ExtDiag(idx)%axes = 3
     ExtDiag(idx)%name = 'tendency_of_air_temperature_due_to_shortwave_heating_assuming_clear_sky'
-    ExtDiag(idx)%desc = 'temperature tendency due to clear sky shortwave radiation'
+    ExtDiag(idx)%desc = 'isntantaneous temperature tendency due to clear sky shortwave radiation'
     ExtDiag(idx)%unit = 'K/s'
-    ExtDiag(idx)%time_avg = .true.
     ExtDiag(idx)%mod_name = 'gfs_phys'
     allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
@@ -2538,10 +2529,9 @@ module GFS_diagnostics
     idx = idx + 1
     ExtDiag(idx)%axes = 3
     ExtDiag(idx)%name = 'tendency_of_specific_humidity_due_to_turbulence'
-    ExtDiag(idx)%desc = 'water vapor tendency due to turbulence scheme'
+    ExtDiag(idx)%desc = 'isntantaneous water vapor tendency due to turbulence scheme'
     ExtDiag(idx)%unit = 'kg/kg/s'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    ExtDiag(idx)%time_avg = .true.
     allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
       ExtDiag(idx)%data(nb)%var3 => IntDiag(nb)%q_dt(:,:,1)
@@ -2550,10 +2540,9 @@ module GFS_diagnostics
     idx = idx + 1
     ExtDiag(idx)%axes = 3
     ExtDiag(idx)%name = 'tendency_of_specific_humidity_due_to_deep_convection'
-    ExtDiag(idx)%desc = 'water vapor tendency due to deep convection'
+    ExtDiag(idx)%desc = 'isntantaneous water vapor tendency due to deep convection'
     ExtDiag(idx)%unit = 'kg/kg/s'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    ExtDiag(idx)%time_avg = .true.
     allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
       ExtDiag(idx)%data(nb)%var3 => IntDiag(nb)%q_dt(:,:,2)
@@ -2562,10 +2551,9 @@ module GFS_diagnostics
     idx = idx + 1
     ExtDiag(idx)%axes = 3
     ExtDiag(idx)%name = 'tendency_of_specific_humidity_due_to_shallow_convection'
-    ExtDiag(idx)%desc = 'water vapor tendency due to shallow convection'
+    ExtDiag(idx)%desc = 'isntantaneous water vapor tendency due to shallow convection'
     ExtDiag(idx)%unit = 'kg/kg/s'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    ExtDiag(idx)%time_avg = .true.
     allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
       ExtDiag(idx)%data(nb)%var3 => IntDiag(nb)%q_dt(:,:,3)
@@ -2574,10 +2562,9 @@ module GFS_diagnostics
     idx = idx + 1
     ExtDiag(idx)%axes = 3
     ExtDiag(idx)%name = 'tendency_of_specific_humidity_due_to_microphysics'
-    ExtDiag(idx)%desc = 'water vapor tendency due to microphysics'
+    ExtDiag(idx)%desc = 'isntantaneous water vapor tendency due to microphysics'
     ExtDiag(idx)%unit = 'kg/kg/s'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    ExtDiag(idx)%time_avg = .true.
     allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
       ExtDiag(idx)%data(nb)%var3 => IntDiag(nb)%q_dt(:,:,4)
@@ -2586,10 +2573,9 @@ module GFS_diagnostics
     idx = idx + 1
     ExtDiag(idx)%axes = 3
     ExtDiag(idx)%name = 'tendency_of_specific_humidity_due_to_change_in_atmosphere_mass'
-    ExtDiag(idx)%desc = 'residual water vapor tendency'
+    ExtDiag(idx)%desc = 'isntantaneous residual water vapor tendency'
     ExtDiag(idx)%unit = 'kg/kg/s'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    ExtDiag(idx)%time_avg = .true.
     allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
       ExtDiag(idx)%data(nb)%var3 => IntDiag(nb)%q_dt(:,:,5)

--- a/FV3/gfsphysics/GFS_layer/GFS_diagnostics.F90
+++ b/FV3/gfsphysics/GFS_layer/GFS_diagnostics.F90
@@ -2330,10 +2330,6 @@ module GFS_diagnostics
       ExtDiag(idx)%data(nb)%var3 => IntDiag(nb)%dt3dt(:,:,9)
     enddo
 
-! Applying a time_avg converts these t_dt_* quantities to average tendencies, 
-! because it amounts to dividing the total increments (what are stored in the
-! diagnostics buckets) by the total time elapsed for the diagnostics interval
-! (in seconds).  
     idx = idx + 1
     ExtDiag(idx)%axes = 3
     ExtDiag(idx)%name = 'tendency_of_air_temperature_due_to_longwave_heating'
@@ -2522,10 +2518,6 @@ module GFS_diagnostics
       ExtDiag(idx)%data(nb)%var3 => IntDiag(nb)%dv3dt(:,:,4)
     enddo
 
-! Applying a time_avg converts these qv_dt_* quantities to average tendencies, 
-! because it amounts to dividing the total increments (what are stored in the
-! diagnostics buckets) by the total time elapsed for the diagnostics interval
-! (in seconds). 
     idx = idx + 1
     ExtDiag(idx)%axes = 3
     ExtDiag(idx)%name = 'tendency_of_specific_humidity_due_to_turbulence'

--- a/FV3/gfsphysics/GFS_layer/GFS_diagnostics.F90
+++ b/FV3/gfsphysics/GFS_layer/GFS_diagnostics.F90
@@ -2333,7 +2333,7 @@ module GFS_diagnostics
     idx = idx + 1
     ExtDiag(idx)%axes = 3
     ExtDiag(idx)%name = 'tendency_of_air_temperature_due_to_longwave_heating'
-    ExtDiag(idx)%desc = 'isntantaneous temperature tendency due to longwave radiation'
+    ExtDiag(idx)%desc = 'instantaneous temperature tendency due to longwave radiation'
     ExtDiag(idx)%unit = 'K/s'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     allocate (ExtDiag(idx)%data(nblks))
@@ -2344,7 +2344,7 @@ module GFS_diagnostics
     idx = idx + 1
     ExtDiag(idx)%axes = 3
     ExtDiag(idx)%name = 'tendency_of_air_temperature_due_to_shortwave_heating'
-    ExtDiag(idx)%desc = 'isntantaneous temperature tendency due to shortwave radiation'
+    ExtDiag(idx)%desc = 'instantaneous temperature tendency due to shortwave radiation'
     ExtDiag(idx)%unit = 'K/s'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     allocate (ExtDiag(idx)%data(nblks))
@@ -2355,7 +2355,7 @@ module GFS_diagnostics
     idx = idx + 1
     ExtDiag(idx)%axes = 3
     ExtDiag(idx)%name = 'tendency_of_air_temperature_due_to_turbulence'
-    ExtDiag(idx)%desc = 'isntantaneous temperature tendency due to turbulence scheme'
+    ExtDiag(idx)%desc = 'instantaneous temperature tendency due to turbulence scheme'
     ExtDiag(idx)%unit = 'K/s'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     allocate (ExtDiag(idx)%data(nblks))
@@ -2366,7 +2366,7 @@ module GFS_diagnostics
     idx = idx + 1
     ExtDiag(idx)%axes = 3
     ExtDiag(idx)%name = 'tendency_of_air_temperature_due_to_deep_convection'
-    ExtDiag(idx)%desc = 'isntantaneous temperature tendency due to deep convection'
+    ExtDiag(idx)%desc = 'instantaneous temperature tendency due to deep convection'
     ExtDiag(idx)%unit = 'K/s'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     allocate (ExtDiag(idx)%data(nblks))
@@ -2377,7 +2377,7 @@ module GFS_diagnostics
     idx = idx + 1
     ExtDiag(idx)%axes = 3
     ExtDiag(idx)%name = 'tendency_of_air_temperature_due_to_shallow_convection'
-    ExtDiag(idx)%desc = 'isntantaneous temperature tendency due to shallow convection'
+    ExtDiag(idx)%desc = 'instantaneous temperature tendency due to shallow convection'
     ExtDiag(idx)%unit = 'K/s'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     allocate (ExtDiag(idx)%data(nblks))
@@ -2388,7 +2388,7 @@ module GFS_diagnostics
     idx = idx + 1
     ExtDiag(idx)%axes = 3
     ExtDiag(idx)%name = 'tendency_of_air_temperature_due_to_microphysics'
-    ExtDiag(idx)%desc = 'isntantaneous temperature tendency due to micro-physics'
+    ExtDiag(idx)%desc = 'instantaneous temperature tendency due to micro-physics'
     ExtDiag(idx)%unit = 'K/s'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     allocate (ExtDiag(idx)%data(nblks))
@@ -2399,7 +2399,7 @@ module GFS_diagnostics
     idx = idx + 1
     ExtDiag(idx)%axes = 3
     ExtDiag(idx)%name = 'tendency_of_air_temperature_due_to_dissipation_of_gravity_waves'
-    ExtDiag(idx)%desc = 'isntantaneous temperature tendency due to gravity wave drag'
+    ExtDiag(idx)%desc = 'instantaneous temperature tendency due to gravity wave drag'
     ExtDiag(idx)%unit = 'K/s'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     allocate (ExtDiag(idx)%data(nblks))
@@ -2410,7 +2410,7 @@ module GFS_diagnostics
     idx = idx + 1
     ExtDiag(idx)%axes = 3
     ExtDiag(idx)%name = 'tendency_of_air_temperature_due_to_longwave_heating_assuming_clear_sky'
-    ExtDiag(idx)%desc = 'isntantaneous temperature tendency due to clear sky longwave radiation'
+    ExtDiag(idx)%desc = 'instantaneous temperature tendency due to clear sky longwave radiation'
     ExtDiag(idx)%unit = 'K/s'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     allocate (ExtDiag(idx)%data(nblks))
@@ -2421,7 +2421,7 @@ module GFS_diagnostics
     idx = idx + 1
     ExtDiag(idx)%axes = 3
     ExtDiag(idx)%name = 'tendency_of_air_temperature_due_to_shortwave_heating_assuming_clear_sky'
-    ExtDiag(idx)%desc = 'isntantaneous temperature tendency due to clear sky shortwave radiation'
+    ExtDiag(idx)%desc = 'instantaneous temperature tendency due to clear sky shortwave radiation'
     ExtDiag(idx)%unit = 'K/s'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     allocate (ExtDiag(idx)%data(nblks))
@@ -2521,7 +2521,7 @@ module GFS_diagnostics
     idx = idx + 1
     ExtDiag(idx)%axes = 3
     ExtDiag(idx)%name = 'tendency_of_specific_humidity_due_to_turbulence'
-    ExtDiag(idx)%desc = 'isntantaneous water vapor tendency due to turbulence scheme'
+    ExtDiag(idx)%desc = 'instantaneous water vapor tendency due to turbulence scheme'
     ExtDiag(idx)%unit = 'kg/kg/s'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     allocate (ExtDiag(idx)%data(nblks))
@@ -2532,7 +2532,7 @@ module GFS_diagnostics
     idx = idx + 1
     ExtDiag(idx)%axes = 3
     ExtDiag(idx)%name = 'tendency_of_specific_humidity_due_to_deep_convection'
-    ExtDiag(idx)%desc = 'isntantaneous water vapor tendency due to deep convection'
+    ExtDiag(idx)%desc = 'instantaneous water vapor tendency due to deep convection'
     ExtDiag(idx)%unit = 'kg/kg/s'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     allocate (ExtDiag(idx)%data(nblks))
@@ -2543,7 +2543,7 @@ module GFS_diagnostics
     idx = idx + 1
     ExtDiag(idx)%axes = 3
     ExtDiag(idx)%name = 'tendency_of_specific_humidity_due_to_shallow_convection'
-    ExtDiag(idx)%desc = 'isntantaneous water vapor tendency due to shallow convection'
+    ExtDiag(idx)%desc = 'instantaneous water vapor tendency due to shallow convection'
     ExtDiag(idx)%unit = 'kg/kg/s'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     allocate (ExtDiag(idx)%data(nblks))
@@ -2554,7 +2554,7 @@ module GFS_diagnostics
     idx = idx + 1
     ExtDiag(idx)%axes = 3
     ExtDiag(idx)%name = 'tendency_of_specific_humidity_due_to_microphysics'
-    ExtDiag(idx)%desc = 'isntantaneous water vapor tendency due to microphysics'
+    ExtDiag(idx)%desc = 'instantaneous water vapor tendency due to microphysics'
     ExtDiag(idx)%unit = 'kg/kg/s'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     allocate (ExtDiag(idx)%data(nblks))
@@ -2565,7 +2565,7 @@ module GFS_diagnostics
     idx = idx + 1
     ExtDiag(idx)%axes = 3
     ExtDiag(idx)%name = 'tendency_of_specific_humidity_due_to_change_in_atmosphere_mass'
-    ExtDiag(idx)%desc = 'isntantaneous residual water vapor tendency'
+    ExtDiag(idx)%desc = 'instantaneous residual water vapor tendency'
     ExtDiag(idx)%unit = 'kg/kg/s'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     allocate (ExtDiag(idx)%data(nblks))

--- a/FV3/gfsphysics/GFS_layer/GFS_physics_driver.F90
+++ b/FV3/gfsphysics/GFS_layer/GFS_physics_driver.F90
@@ -5366,9 +5366,9 @@ module module_physics_driver
         endif
 
         call update_temperature_tendency_diagnostics(Diag%t_dt, dt3dt_initial, Diag%dt3dt, &
-            specific_heat, im, levs)
+            specific_heat, im, levs, dtp)
         call update_water_vapor_tendency_diagnostics(Diag%q_dt, dq3dt_initial, Diag%dq3dt, &
-            Statein%qgrs(:,:,1:nwat), Stateout%gq0(:,:,1:nwat), im, levs, nwat)
+            Statein%qgrs(:,:,1:nwat), Stateout%gq0(:,:,1:nwat), im, levs, nwat, dtp)
       endif
 
 !     if (kdt > 2 ) stop
@@ -5709,16 +5709,17 @@ module module_physics_driver
       ! core is hydrostatic to account for how the temperature tendency is
       ! adjusted within the dynamical core.
       subroutine update_temperature_tendency_diagnostics(t_dt, dt3dt_initial, dt3dt_final, specific_heat, &
-        im, levs)
+        im, levs, timestep)
         integer, intent(in) :: im, levs
         real(kind=kind_phys), intent(in), dimension(1:im,1:levs,9) :: dt3dt_initial, dt3dt_final
         real(kind=kind_phys), intent(inout) :: t_dt(1:im,1:levs,9)
         real(kind=kind_phys), intent(in), dimension(1:im,1:levs) :: specific_heat
+        real(kind=kind_phys), intent(in) :: timestep
 
         integer :: i
 
         do i = 1, 9
-          t_dt(:,:,i) = t_dt(:,:,i) + con_cp * (dt3dt_final(:,:,i) - dt3dt_initial(:,:,i)) / specific_heat(:,:)
+          t_dt(:,:,i) = con_cp * (dt3dt_final(:,:,i) - dt3dt_initial(:,:,i)) / (timestep * specific_heat(:,:))
         enddo
       end subroutine update_temperature_tendency_diagnostics
 
@@ -5735,11 +5736,12 @@ module module_physics_driver
       ! This residual is typically small compared to the tendencies induced by the
       ! physics parameterizations themselves.
       subroutine update_water_vapor_tendency_diagnostics(q_dt, dq3dt_initial, dq3dt_final, &
-        q_initial, q_final, im, levs, nwat)
+        q_initial, q_final, im, levs, nwat, timestep)
         integer, intent(in) :: im, levs, nwat
         real(kind=kind_phys), intent(inout) :: q_dt(1:im,1:levs,5)
         real(kind=kind_phys), intent(in), dimension(1:im,1:levs,1:9) :: dq3dt_initial, dq3dt_final
         real(kind=kind_phys), intent(in), dimension(1:im,1:levs,1:nwat) :: q_initial, q_final
+        real(kind=kind_phys), intent(in) :: timestep
 
         integer :: i
         real(kind=kind_phys), dimension(1:im,1:levs) :: initial_dynamics_denominator, final_dynamics_denominator
@@ -5751,11 +5753,11 @@ module module_physics_driver
         final_dynamics_denominator = 1.0 + sum(dq3dt_final(:,:,1:4) - dq3dt_initial(:,:,1:4), 3) + sum(q_final(:,:,2:nwat), 3)
 
         do i = 1, 4
-          q_dt(:,:,i) = q_dt(:,:,i) + (dq3dt_final(:,:,i) - dq3dt_initial(:,:,i)) / final_dynamics_denominator
+          q_dt(:,:,i) = (dq3dt_final(:,:,i) - dq3dt_initial(:,:,i)) / (timestep * final_dynamics_denominator)
         enddo
 
         ! Compute the residual tendency.
-        q_dt(:,:,5) = q_dt(:,:,5) + q_initial(:,:,1) * ((1.0 / final_dynamics_denominator) - (1.0 / initial_dynamics_denominator))
+        q_dt(:,:,5) = q_initial(:,:,1) * ((1.0 / final_dynamics_denominator) - (1.0 / initial_dynamics_denominator)) / timestep
       end subroutine update_water_vapor_tendency_diagnostics
 !> @}
 


### PR DESCRIPTION
While useful in SHiELD, where we run the model with a shorter timestep than the diagnostics interval, having the per-physics-component tendency diagnostics implemented in FV3GFS as time averages is actually inconvenient for us.  For instance, it would be convenient for us to record instantaneous physics tendencies, but save them out every two hours.  The current way the physics diagnostics are implemented in SHiELD and FV3GFS precludes this.  See an illustration of the existing problem in  [this notebook](https://github.com/VulcanClimateModeling/explore/blob/master/spencerc/2020-08-27-nudge-to-fine-test/2020-08-27-nudge-to-fine-test.ipynb).

These modified diagnostics are tested in a similar way to the original implementations [here](https://github.com/VulcanClimateModeling/explore/blob/master/spencerc/2020-08-10-fv3gfs-diagnostics/2020-08-27-fv3gfs-diagnostics.ipynb).  All looks good.