### PR TITLE
Added install target which works if ccpp is enabled

### DIFF
--- a/FV3/makefile
+++ b/FV3/makefile
@@ -55,8 +55,16 @@ libs_no_dycore: fms_check
 	$(MAKE) -C ipd                   $(MAKE_OPTS) FMS_DIR=$(FMS_DIR) 32BIT=N  # force gfs physics to 64bit
 	$(MAKE) -C io                    $(MAKE_OPTS) FMS_DIR=$(FMS_DIR)
 
-$(FV3_EXE): atmos_model.o coupler_main.o module_fv3_config.o ccpp/driver/libccppdriver.a atmos_cubed_sphere/libfv3core.a io/libfv3io.a ipd/libipd.a gfsphysics/libgfsphys.a ../stochastic_physics/libstochastic_physics.a cpl/libfv3cpl.a
+FV3_LIBS = ccpp/driver/libccppdriver.a atmos_cubed_sphere/libfv3core.a io/libfv3io.a ipd/libipd.a gfsphysics/libgfsphys.a ../stochastic_physics/libstochastic_physics.a cpl/libfv3cpl.a coarse_graining/libfv3coarse_graining.a
+$(FV3_EXE): atmos_model.o coupler_main.o module_fv3_config.o $(FV3_LIBS)
 	$(LD) -o $@ $^ $(NCEPLIBS) $(LDFLAGS)
+
+install: $(FV3_EXE) $(FV3_LIBS) libfv3.a
+	mkdir -p $(PREFIX)/bin $(PREFIX)/lib $(PREFIX)/include $(PREFIX)/lib/pkgconfig
+	install -t $(PREFIX)/bin/ $(FV3_EXE)
+	install -t $(PREFIX)/lib/ $(FV3_LIBS) libfv3.a
+	install -t $(PREFIX)/include *.mod ccpp/driver/*.mod gfsphysics/*.mod ipd/*.mod cpl/*.mod io/*.mod atmos_cubed_sphere/*.mod ../stochastic_physics/*.mod
+	bash write_pkg_config.sh $(PREFIX) "-lfv3 $(FV3_LIB_FLAGS) $(NCEPLIBS) $(LDFLAGS)" "$(CPPDEFS) $(CPPFLAGS) $(FPPFLAGS) $(FFLAGS) $(OTHERFLAGS) $(OTHER_FFLAGS) $(ESMF_INC)" > $(PREFIX)/lib/pkgconfig/fv3.pc
 
 else
 libs: fms_check
@@ -81,9 +89,6 @@ FV3_LIB_FLAGS = -lfv3core -lfv3io -lipd -lgfsphys -lstochastic_physics -lfv3cpl 
 $(FV3_EXE): atmos_model.o coupler_main.o module_fv3_config.o $(FV3_LIBS)
 	$(LD)  -o $@  atmos_model.o coupler_main.o module_fv3_config.o $(FV3_LIB_FLAGS) $(NCEPLIBS) $(LDFLAGS) 
 
-libfv3.a: atmos_model.o module_fv3_config.o
-	ar crs $@ $^
-
 install: $(FV3_EXE) $(FV3_LIBS) libfv3.a
 	mkdir -p $(PREFIX)/bin $(PREFIX)/lib $(PREFIX)/include $(PREFIX)/lib/pkgconfig
 	install -t $(PREFIX)/bin/ $(FV3_EXE)
@@ -93,6 +98,8 @@ install: $(FV3_EXE) $(FV3_LIBS) libfv3.a
 
 endif
 
+libfv3.a: atmos_model.o module_fv3_config.o
+	ar crs $@ $^
 
 $(FV3CAP_LIB): atmos_model.o module_fv3_config.o module_fcst_grid_comp.o time_utils.o fv3_cap.o
 	ar rv $(FV3CAP_LIB) $?


### PR DESCRIPTION
The current pkg-config install target only works if CCPP is not used in compilation. This PR adds a corresponding make target in the ifdef for when CCPP shows up in the compilation flags. The target itself is not tested, because we don't compile with CCPP.