### PR TITLE
[VCMML-563] Ensure column moistening implied by nudging specific humidity is subtracted from the precipitation during the same timestep

### DIFF
--- a/FV3/atmos_cubed_sphere/driver/fvGFS/atmosphere.F90
+++ b/FV3/atmos_cubed_sphere/driver/fvGFS/atmosphere.F90
@@ -902,6 +902,7 @@ contains
 
  end subroutine atmosphere_control_data
 
+
 !>@brief The subroutine 'atmosphere_grid_ctr' is an API that returns the longitude and 
 !! latitude cell centers of the current MPI-rank.
  subroutine atmosphere_grid_ctr (lon, lat)

--- a/FV3/atmos_cubed_sphere/driver/fvGFS/atmosphere.F90
+++ b/FV3/atmos_cubed_sphere/driver/fvGFS/atmosphere.F90
@@ -2238,7 +2238,7 @@ contains
  end subroutine subtract_column_moistening_from_precipitation
 
  subroutine update_physics_precipitation_for_qv_nudging(Atm_block, IPD_Data)
-   type (block_control_type), intent(in) :: Atm_block
+   type(block_control_type), intent(in) :: Atm_block
    type(IPD_data_type), intent(inout) :: IPD_Data(:)
 
    real(kind=kind_phys), allocatable :: column_moistening_implied_by_nudging(:)

--- a/FV3/atmos_model.F90
+++ b/FV3/atmos_model.F90
@@ -79,6 +79,7 @@ use atmosphere_mod,     only: atmosphere_scalar_field_halo
 use atmosphere_mod,     only: atmosphere_get_bottom_layer
 use atmosphere_mod,     only: set_atmosphere_pelist
 use atmosphere_mod,     only: Atm, mytile
+use atmosphere_mod,     only: atmosphere_column_moistening_implied_by_nudging
 use block_control_mod,  only: block_control_type, define_blocks_packed
 use DYCORE_typedefs,    only: DYCORE_data_type, DYCORE_diag_type
 #ifdef CCPP
@@ -157,6 +158,7 @@ public Atm_block, IPD_Data, IPD_Control
      type(time_type)               :: Time_init          ! reference time.
      type(grid_box_type)           :: grid               ! hold grid information needed for 2nd order conservative flux exchange 
      type(IPD_diag_type), pointer, dimension(:) :: Diag
+     logical                       :: nudge              ! whether nudging to NCEP analysis is active in the dynamical core
  end type atmos_data_type
                                                          ! to calculate gradient on cubic sphere grid.
 !</PUBLICTYPE >
@@ -519,7 +521,7 @@ subroutine atmos_model_init (Atmos, Time_init, Time, Time_step)
 !-----------------------------------------------------------------------
 !--- before going any further check definitions for 'blocks'
 !-----------------------------------------------------------------------
-   call atmosphere_control_data (isc, iec, jsc, jec, nlev, p_hydro, hydro, tile_num)
+   call atmosphere_control_data (isc, iec, jsc, jec, nlev, p_hydro, hydro, tile_num, Atmos%nudge)
    call define_blocks_packed ('atmos_model', Atm_block, isc, iec, jsc, jec, nlev, &
                               blocksize, block_message)
    
@@ -860,6 +862,11 @@ subroutine update_atmos_model_state (Atmos)
     call mpp_clock_begin(fv3Clock)
     call mpp_clock_begin(updClock)
     call atmosphere_state_update (Atmos%Time, IPD_Data, IAU_Data, Atm_block, flip_vc)
+
+    if (Atmos%nudge) then
+      call update_precipitation_for_qv_nudging
+    endif
+
     call mpp_clock_end(updClock)
     call mpp_clock_end(fv3Clock)
 
@@ -2713,5 +2720,42 @@ end subroutine atmos_data_type_chksum
 
   end subroutine addLsmask2grid
 !------------------------------------------------------------------------------
+
+  ! If nudging the specific humidity to NCEP analysis, subtract the column-integrated
+  ! specific humidity nudging tendency from the precipitation felt by the surface.
+  subroutine subtract_column_moistening_from_precipitation(moistening, im, timestep, precipitation)
+    integer, intent(in) :: im
+    real(kind=IPD_kind_phys), intent(in) :: timestep
+    real(kind=IPD_kind_phys), intent(in) :: moistening(1:im)
+    real(kind=IPD_kind_phys), intent(inout) :: precipitation(1:im)
+    real(kind=IPD_kind_phys) :: m_per_mm
+
+    m_per_mm = 1.0 / 1000.0
+
+    precipitation = precipitation - moistening * timestep * m_per_mm
+    where (precipitation .lt. 0.0)
+       precipitation = 0.0
+    endwhere
+  end subroutine subtract_column_moistening_from_precipitation
+
+  subroutine update_precipitation_for_qv_nudging
+    real(kind=IPD_kind_phys), allocatable :: column_moistening_implied_by_nudging(:)
+    integer :: nblks, nb, im
+
+    nblks = Atm_block%nblks
+
+    do nb = 1, Atm_block%nblks
+      im = Atm_block%blksz(nb)
+      allocate(column_moistening_implied_by_nudging(1:im))
+      call atmosphere_column_moistening_implied_by_nudging(nb, im, Atm_block, column_moistening_implied_by_nudging)
+      call subtract_column_moistening_from_precipitation( &
+        column_moistening_implied_by_nudging, &
+        Atm_block%blksz(nb), &
+        IPD_control%dtp, &
+        IPD_Data(nb)%Sfcprop%tprcp)
+
+      deallocate(column_moistening_implied_by_nudging)
+    enddo
+  end subroutine update_precipitation_for_qv_nudging
 
 end module atmos_model_mod

--- a/FV3/atmos_model.F90
+++ b/FV3/atmos_model.F90
@@ -2750,10 +2750,9 @@ end subroutine atmos_data_type_chksum
       call atmosphere_column_moistening_implied_by_nudging(nb, im, Atm_block, column_moistening_implied_by_nudging)
       call subtract_column_moistening_from_precipitation( &
         column_moistening_implied_by_nudging, &
-        Atm_block%blksz(nb), &
+        im, &
         IPD_control%dtp, &
         IPD_Data(nb)%Sfcprop%tprcp)
-
       deallocate(column_moistening_implied_by_nudging)
     enddo
   end subroutine update_precipitation_for_qv_nudging

--- a/FV3/gfsphysics/GFS_layer/GFS_physics_driver.F90
+++ b/FV3/gfsphysics/GFS_layer/GFS_physics_driver.F90
@@ -5345,10 +5345,6 @@ module module_physics_driver
         Diag%T02MIN(I)  = MIN(Diag%T02MIN(I), Sfcprop%t2m(i))  !<--- Hourly min 2m T
       enddo
 
-      if (Statein%dycore_nudge) then
-        call adjust_precipitation_for_qv_nudging(Statein%column_moistening_implied_by_nudging, im, dtp, Sfcprop%tprcp)
-      endif
-
       if (Model%ldiag3d) then
         ! Update t_dt_* and q_dt_* diagnostics such that they represent temperature
         ! and water vapor tendencies contributed by each component of the physics,
@@ -5566,23 +5562,6 @@ module module_physics_driver
       return
 
       end subroutine moist_bud2
-
-      ! If nudging the specific humidity to NCEP analysis, subtract the column-integrated
-      ! specific humidity nudging tendency from the precipitation felt by the surface.
-      subroutine adjust_precipitation_for_qv_nudging(moistening, im, timestep, precipitation)
-        integer, intent(in) :: im
-        real(kind=kind_phys), intent(in) :: timestep
-        real(kind=kind_phys), intent(in) :: moistening(1:im)
-        real(kind=kind_phys), intent(inout) :: precipitation(1:im)
-        real(kind=kind_phys) :: m_per_mm
-
-        m_per_mm = 1.0 / 1000.0
-
-        precipitation = precipitation - moistening * timestep * m_per_mm
-        where (precipitation .lt. 0.0)
-           precipitation = 0.0
-        endwhere
-      end subroutine adjust_precipitation_for_qv_nudging
 
       subroutine moist_cv_nwat6(initial_dynamics_q, physics_q, pressure_on_interfaces, &
             im, levs, nwat, ntqv, ntcw, ntiw, ntrw, ntsw, ntgl, cvm)

--- a/FV3/gfsphysics/GFS_layer/GFS_typedefs.F90
+++ b/FV3/gfsphysics/GFS_layer/GFS_typedefs.F90
@@ -185,11 +185,9 @@ module GFS_typedefs
     real (kind=kind_phys), pointer :: stc (:,:)   => null()  !< soil temperature content
     real (kind=kind_phys), pointer :: slc (:,:)   => null()  !< soil liquid water content
     real (kind=kind_phys), pointer :: atm_ts (:)  => null() !< surface temperature from dynamical core
-    real (kind=kind_phys), pointer :: column_moistening_implied_by_nudging (:) => null() !< Implied moistening from nudging specific humidity
  
     logical, pointer :: dycore_hydrostatic        => null()  !< whether the dynamical core is hydrostatic
     integer, pointer :: nwat                      => null()  !< number of water species used in the model
-    logical, pointer :: dycore_nudge              => null()  !< whether nudging is active in the dynamical core
     contains
       procedure :: create  => statein_create  !<   allocate array data
   end type GFS_statein_type
@@ -2002,17 +2000,11 @@ module GFS_typedefs
     allocate (Statein%atm_ts(IM))
     Statein%atm_ts = clear_val
 
-    allocate (Statein%column_moistening_implied_by_nudging(IM))
-    Statein%column_moistening_implied_by_nudging = clear_val
-
     allocate(Statein%dycore_hydrostatic)
     Statein%dycore_hydrostatic = .true.
 
     allocate(Statein%nwat)
     Statein%nwat = 6
-
-    allocate(Statein%dycore_nudge)
-    Statein%dycore_nudge = .false.
   end subroutine statein_create
 
 


### PR DESCRIPTION
This PR fixes a bug introduced in #53. The way #53 was written we were adding the column moistening implied by nudging specific humidity from timestep `n` to the precipitation in timestep `n+1`.  This meant that in the first timestep, we were subtracting the uninitialized value of `column_moistening_implied_by_nudging` -- which could be anything -- from the precipitation felt in the physics.  In addition to being non-sensical, depending on what those uninitialized values were, this could lead to the model crashing.  

This PR fixes this by instead ensuring that we subtract the column moistening implied by nudging the specific humidity in timestep `n` to the precipitation in `n`.  Verification that this works can be found in the plots below.  

![soil-moisture](https://user-images.githubusercontent.com/6628425/94746193-35341100-034a-11eb-8fbb-f4d4ea6ca7a6.png)

![soil-moisture-diff-segmented-minus-updated](https://user-images.githubusercontent.com/6628425/94746718-534e4100-034b-11eb-9eac-b046fa030375.png)

Here we can see that (1) the overall evolution of soil moisture in the model is similar to what it was before, and (2) that restarting the model midway does not significantly alter the trajectory (it's a known issue that the model does not restart exactly where it left off, so we don't expect bitwise reproduction).  The dashed line in the panels for the segmented run represents the time the model was restarted.

The notebook that produced these plots as well as configurations for each of the test cases can be found [here](https://github.com/VulcanClimateModeling/explore/tree/master/spencerc/2020-09-29-nudge-to-obs-testing).

Resolves VCMML-563