### PR TITLE
Fix/makefile tagnames

### DIFF
--- a/.jenkins/build_docker_images.sh
+++ b/.jenkins/build_docker_images.sh
@@ -18,7 +18,7 @@ make build build_serialize_gt4py_dev
 #   - push image to VCM's Google Container Repository (necessary?)
 #   - create a tar archive of the image
 #   - store tar archive in a Google Storage Bucket
-declare -a tags=("gnu9-mpich314-nocuda" "gnu9-mpich314-nocuda-serialize")
+declare -a tags=("gnu9-mpich314-nocuda" "gnu9-mpich314-nocuda-serialize-gt4pydev")
 for tag in ${tags} ; do
     container=us.gcr.io/vcm-ml/fv3gfs-compiled:${tag}
     tar_file=fv3gfs-compiled-${tag}.tar

--- a/.jenkins/build_docker_images.sh
+++ b/.jenkins/build_docker_images.sh
@@ -4,14 +4,17 @@
 export DOCKER_BUILDKIT=1
 export BUILDKIT_PROGRESS=plain
 targets="build build_serialize_gt4py_dev"
-tags="hpc hpc-serialize"
+tags="gnu9-mpich314-nocuda gnu9-mpich314-nocuda-serialize"
 
 # Speed-up the compilations by using pre-built MPI, FMS, and ESMF images
 export BUILD_FROM_INTERMEDIATE=y
 
+# We build and test Docker images without CUDA support
+export CUDA=n
+
 # Build FV3 without and with Serialbox support enabled
 make pull_deps
-COMPILED_TAG_NAME=hpc make ${targets} 
+make ${targets} 
 
 # For each newly built Docker image:
 #   - push image to VCM's Google Container Repository (necessary?)

--- a/.jenkins/build_docker_images.sh
+++ b/.jenkins/build_docker_images.sh
@@ -3,8 +3,6 @@
 # Set variable to allow parallel building in the Docker image creation
 export DOCKER_BUILDKIT=1
 export BUILDKIT_PROGRESS=plain
-targets="build build_serialize_gt4py_dev"
-tags="gnu9-mpich314-nocuda gnu9-mpich314-nocuda-serialize"
 
 # Speed-up the compilations by using pre-built MPI, FMS, and ESMF images
 export BUILD_FROM_INTERMEDIATE=y
@@ -14,12 +12,13 @@ export CUDA=n
 
 # Build FV3 without and with Serialbox support enabled
 make pull_deps
-make ${targets} 
+make build build_serialize_gt4py_dev 
 
 # For each newly built Docker image:
 #   - push image to VCM's Google Container Repository (necessary?)
 #   - create a tar archive of the image
 #   - store tar archive in a Google Storage Bucket
+declare -a tags=("gnu9-mpich314-nocuda" "gnu9-mpich314-nocuda-serialize")
 for tag in ${tags} ; do
     container=us.gcr.io/vcm-ml/fv3gfs-compiled:${tag}
     tar_file=fv3gfs-compiled-${tag}.tar

--- a/.jenkins/sarus_run_test.sh
+++ b/.jenkins/sarus_run_test.sh
@@ -28,7 +28,7 @@ export SCRATCH_DIR=${PWD}
 
 
 # Run c12 regression test on each Docker image
-declare -a tags=("gnu9-mpich314-nocuda" "gnu9-mpich314-nocuda-serialize")
+declare -a tags=("gnu9-mpich314-nocuda" "gnu9-mpich314-nocuda-serialize-gt4pydev")
 for tag in ${tags}; do
     # Copy archived version of the Docker image from a Google Storage Bucket
     tar_file=fv3gfs-compiled-${tag}.tar

--- a/.jenkins/sarus_run_test.sh
+++ b/.jenkins/sarus_run_test.sh
@@ -14,7 +14,7 @@ gcloud auth configure-docker
 # Set up the working directing for the c12 test
 # Using the standard python virtual environment for Piz Daint
 # defined in https://github.com/VulcanClimateModeling/daint_venv
-cd examples
+cd example
 . /project/d107/install/venv/sn_1.0/bin/activate
 pip install -r ../requirements.txt
 python -c 'import fv3config; import yaml; fid=open("../tests/pytest/config/default.yml", "r"); config = yaml.safe_load(fid); fv3config.write_run_directory(config, "./c12_test")'

--- a/.jenkins/sarus_run_test.sh
+++ b/.jenkins/sarus_run_test.sh
@@ -28,7 +28,7 @@ export SCRATCH_DIR=${PWD}
 
 
 # Run c12 regression test on each Docker image
-declare -a tags=("hpc" "hpc-serialize")
+declare -a tags=("gnu9-mpich314-nocuda" "gnu9-mpich314-nocuda-serialize")
 for tag in ${tags}; do
     # Copy archived version of the Docker image from a Google Storage Bucket
     tar_file=fv3gfs-compiled-${tag}.tar

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,6 @@
 # setup (use XXX=<value> make <target> to override)
 GCR_URL ?= us.gcr.io/vcm-ml
 DOCKERFILE ?= docker/Dockerfile
-COMPILED_TAG_NAME ?= latest
-ENVIRONMENT_TAG_NAME ?= latest
 COMPILE_OPTION ?=
 COMPILE_TARGET ?= fv3gfs-compiled
 BUILD_ARGS ?=
@@ -11,24 +9,24 @@ ENVIRONMENT_TARGET ?= fv3gfs-environment
 CUDA ?= n
 OTHER_MOUNTS ?= 
 
-# image names (use XXX_IMAGE=<name> make <target> to override)
-COMPILED_IMAGE ?= $(GCR_URL)/$(COMPILE_TARGET):$(COMPILED_TAG_NAME)
-SERIALIZE_IMAGE ?= $(GCR_URL)/$(COMPILE_TARGET):$(COMPILED_TAG_NAME)-serialize
-ENVIRONMENT_IMAGE ?= $(GCR_URL)/$(ENVIRONMENT_TARGET):$(ENVIRONMENT_TAG_NAME)
-MPI_IMAGE ?= $(GCR_URL)/mpi-build:$(DEP_TAG_NAME)
-FMS_IMAGE ?= $(GCR_URL)/fms-build:$(DEP_TAG_NAME)
-ESMF_IMAGE ?= $(GCR_URL)/esmf-build:$(DEP_TAG_NAME)
-SERIALBOX_IMAGE ?= $(GCR_URL)/serialbox-build:$(DEP_TAG_NAME)
-
 # base images w/ or w/o CUDA
 ifeq ($(CUDA),n)
 	BASE_IMAGE ?= ubuntu:19.10
-	DEP_TAG_NAME ?= gnu9-mpich314-nocuda
+	TAG_NAME ?= gnu9-mpich314-nocuda
 else
 	BASE_IMAGE ?= nvidia/cuda:10.2-devel-ubuntu18.04
-	DEP_TAG_NAME ?= gnu8-mpich314-cuda102
+	TAG_NAME ?= gnu8-mpich314-cuda102
 endif
 BUILD_ARGS += --build-arg BASE_IMAGE=$(BASE_IMAGE)
+
+# image names (use XXX_IMAGE=<name> make <target> to override)
+COMPILED_IMAGE ?= $(GCR_URL)/$(COMPILE_TARGET):$(TAG_NAME)
+SERIALIZE_IMAGE ?= $(GCR_URL)/$(COMPILE_TARGET):$(TAG_NAME)-serialize
+ENVIRONMENT_IMAGE ?= $(GCR_URL)/$(ENVIRONMENT_TARGET):$(TAG_NAME)
+MPI_IMAGE ?= $(GCR_URL)/mpi-build:$(TAG_NAME)
+FMS_IMAGE ?= $(GCR_URL)/fms-build:$(TAG_NAME)
+ESMF_IMAGE ?= $(GCR_URL)/esmf-build:$(TAG_NAME)
+SERIALBOX_IMAGE ?= $(GCR_URL)/serialbox-build:$(TAG_NAME)
 
 # used to shorten build times in CircleCI
 ifeq ($(BUILD_FROM_INTERMEDIATE),y)
@@ -67,10 +65,10 @@ build_serialize_gt4py_dev: ## build container image for generating serialized da
 		$(MAKE) build_compiled
 
 build_debug: ## build container image for debugging
-	COMPILED_TAG_NAME=debug COMPILE_OPTION="REPRO=\\\nDEBUG=Y" $(MAKE) build
+	TAG_NAME=$(TAG_NAME)-debug COMPILE_OPTION="REPRO=\\\nDEBUG=Y" $(MAKE) build
 
 build_coverage: build_environment ## build container image for code coverage analysis
-	COMPILED_TAG_NAME=gcov COMPILED_IMAGE=$(GCR_URL)/$(COMPILE_TARGET):gcov \
+	TAG_NAME=$(TAG_NAME)-gcov COMPILED_IMAGE=$(GCR_URL)/$(COMPILE_TARGET):gcov \
 	COMPILE_OPTION="OPENMP=\\\nREPRO=\\\nDEBUG=Y\\\nGCOV=Y" $(MAKE) build
 
 build_deps: ## build container images of dependnecies (FMS, ESMF, SerialBox)
@@ -102,22 +100,14 @@ enter_serialize: ## run and enter serialization container for development
 		-v $(shell pwd)/FV3:/FV3/original $(OTHER_MOUNTS) \
 		-w /FV3 -it $(SERIALIZE_IMAGE) bash
 
-test: ## run tests (set COMPILED_TAG_NAME to override default)
-	pytest tests/pytest --capture=no --verbose --refdir $(shell pwd)/tests/pytest/reference/circleci --image_version $(COMPILED_TAG_NAME)
+test: ## run tests (set TAG_NAME to override default)
+	pytest tests/pytest --capture=no --verbose --refdir $(shell pwd)/tests/pytest/reference/circleci --image_version $(TAG_NAME)
 
 update_test_reference: test ## update md5 checksums for regression tests
-	cd tests/pytest && bash set_reference.sh $(COMPILED_TAG_NAME)-serialize $(shell pwd)/reference/circleci
+	cd tests/pytest && bash set_reference.sh $(TAG_NAME)-serialize $(shell pwd)/reference/circleci
 
 clean: ## cleanup source tree and test output
 	(cd FV3 && make clean)
 	$(RM) -f inputdata
 	$(RM) -rf tests/pytest/output/*
-
-# TODO 32bit options don't currently build, fix these when issue #4 is fixed.
-#test_32bit:
-#	COMPILED_TAG_NAME=32bit $(MAKE) test
-#
-#build_32bit: build_environment
-#	COMPILED_TAG_NAME=32bit COMPILE_OPTION=32BIT=Y $(MAKE) build
-#
 


### PR DESCRIPTION
A couple of fixes are made:
1) tag names of the dependency images (FMS, MPICH, ESMF and Serialbox) are now set before the image names
   are defined. Thus, these images are now properly named with GNU version, CUDA status and MPICH version.
2) the Jenkins build and run scripts now successfully run with the new example directory and new image tags

These PR also changes the tagging of compiled Docker images to the standard of _image_name:tag_.  Where tag is
a string consisting of GNU version, CUDA status and MPICH version.  This is required as one can now request two
base OS images for Docker image creation: Ubuntu 19:10 with no cuda and Ubuntu 18.04 with Cuda 10.2 support.

These changes will effect other repos such as fv3gfs-wrapper but are necessary to prevent the situation of users/developers not knowing which images they are using.