### PR TITLE
[DSL-49] More verbose message if pattern doesn't match any experiments

### DIFF
--- a/tests/serialized_test_data_generation/make_all_datasets.sh
+++ b/tests/serialized_test_data_generation/make_all_datasets.sh
@@ -34,9 +34,11 @@ else
 fi
 
 # generate list of experiments (and abort if none found)
-EXPERIMENTS=${EXPERIMENT_DIR}/${EXPERIMENT_PATTERN}
+set +e
+EXPERIMENTS=`/bin/ls -1d ${EXPERIMENT_DIR}/${EXPERIMENT_PATTERN} 2> /dev/null`
+set -e
 if [ -z "${EXPERIMENTS}" ] ; then
-    echo "Warning: No matching experiment files for pattern ${EXPERIMENT_PATTERN} in ${EXPERIMENT_DIR} found."
+    echo "Error: No matching experiment files for pattern ${EXPERIMENT_PATTERN} in ${EXPERIMENT_DIR} found."
     exit 1
 fi
 


### PR DESCRIPTION
This is a hotfix which gives better output in case the user specified a EXPERIMENT_PATTERN which does not match any configuration files in the `config` directory.