### PR TITLE
Fix path in update_test_reference Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,10 +98,6 @@ enter_serialize: ## run and enter serialization container for development
 test: ## run tests (set COMPILED_TAG_NAME to override default)
 	pytest tests/pytest --capture=no --verbose --refdir $(shell pwd)/tests/pytest/reference/circleci --image_version $(COMPILED_TAG_NAME)
 
-update_test_reference: ## update md5 checksums for regression tests
-	cd tests/pytest && \
-		bash set_reference.sh $(COMPILED_TAG_NAME)-serialize $(shell pwd)/tests/pytest/reference/circleci
-
 clean: ## cleanup source tree and test output
 	(cd FV3 && make clean)
 	$(RM) -f inputdata

--- a/Makefile
+++ b/Makefile
@@ -99,7 +99,8 @@ test: ## run tests (set COMPILED_TAG_NAME to override default)
 	pytest tests/pytest --capture=no --verbose --refdir $(shell pwd)/tests/pytest/reference/circleci --image_version $(COMPILED_TAG_NAME)
 
 update_test_reference: ## update md5 checksums for regression tests
-	cd tests/pytest && bash set_reference.sh $(COMPILED_TAG_NAME)-serialize $(shell pwd)/reference/circleci
+	cd tests/pytest && \
+		bash set_reference.sh $(COMPILED_TAG_NAME)-serialize $(shell pwd)/tests/pytest/reference/circleci
 
 clean: ## cleanup source tree and test output
 	(cd FV3 && make clean)

--- a/tests/pytest/README.md
+++ b/tests/pytest/README.md
@@ -1,5 +1,5 @@
 Reference files exist in subdirectories of `reference`, e.g. `reference/circleci` for
-the baseline checksums for Circle CI. 
+the baseline md5 checksums for Circle CI. 
 
 Tests need to be passed a reference directory to use. They can be run with
 `pytest --refdir=$(pwd)/reference/circleci`. After running, the output of the
@@ -7,7 +7,7 @@ tests will be present in `output`. These output files can be used to update the
 references, if non-bit-for-bit changes have occurred and those changes are valid.
 
 These files can be updated using
-`set_reference.sh`, by calling e.g. `bash set_reference.sh latest-serialize $(pwd)/reference/circleci`.
+`set_reference.sh`, by calling e.g. `./set_reference.sh latest-serialize $(pwd)/reference/circleci`.
 This script requires you give it an image tag (e.g. `latest-serialize`) and a
 reference directory. The updated references need to be committed into version control.
 
@@ -20,3 +20,4 @@ yaml files to this directory will add new regression tests automatically.
 
 These tests also support running on sarus using the SLURM scheduler, by setting `--image-runner=sarus`
 as an argument to `pytest`.
+

--- a/tests/pytest/set_reference.sh
+++ b/tests/pytest/set_reference.sh
@@ -1,18 +1,43 @@
-set -xe
+#!/bin/bash
+
+# utility script to generate the md5 hashes used to ensure that the model
+# still gives bit-identical results.
+
+# Note: You must have run `make test` in the top-level directory before being
+#       able to generate new references.
+
+# Uage ./set_reference.sh <image tag> <reference dir>
+#   <image tag>      Tag of the Docker image to generate md5 sums (e.g. latest, latest-serialize)
+#   <reference dir>  Directory to store the md5 sums
 
 IMG_TAG=$1
+if [ -z "${IMG_TAG}" ] ; then
+  echo "Error: You must specify an image tag as the first argument"
+  exit 1
+fi
+
 REF_DIR=$2
+if [ -z "${REF_DIR}" ] ; then
+  echo "Error: You must specify a directory to store the md5 sums as the second argument"
+fi
+
 CWD=$(pwd)
 
-for dir in $CWD/output/$IMG_TAG/*/
-do
-    echo $dir
+if ! ls $CWD/output/$IMG_TAG/* &>/dev/null ; then
+  echo "Error: No input directories found in $CWD/output/$IMG_TAG"
+  exit 1
+fi
+
+for dir in $CWD/output/$IMG_TAG/* ; do
     run_name=$(basename ${dir})
     mkdir -p $REF_DIR/$run_name
-    echo $REF_DIR/$run_name
+    echo "Processing $dir, storing md5 sums in $REF_DIR/$run_name"
     cd $dir 
     md5sum *.nc RESTART/*.nc > $REF_DIR/$run_name/md5.txt
     if ls test_data/Gen*.dat test_data/*.json >/dev/null 2>&1; then
         md5sum test_data/Gen*.dat test_data/*.json > $REF_DIR/$run_name/md5_serialize.txt
     fi
+    cd -
 done
+
+exit 0


### PR DESCRIPTION
Remove the Makefile target to update the references. Three reaasons:
- It was broken (the path specified was incorrect).
- It only updates the latest-serialize sums (is not general).
- It was not consistent with the documentation which said to use `set_reference.sh` directly.

Also minor update to documentation and `set_reference.sh`.