### PR TITLE
Exclude fortran_sha.txt from test data validation.

### DIFF
--- a/tests/serialized_test_data_generation/Makefile
+++ b/tests/serialized_test_data_generation/Makefile
@@ -69,7 +69,7 @@ run_model: ## run model using Docker image to generate serialized data
 		-v $(DATA_DIR_HOST):$(DATA_DIR_CONTAINER) $(COMPILED_IMAGE) \
 		/rundir/submit_job.sh
 	cd $(DATA_DIR_HOST) && \
-		md5sum `/bin/ls -1d * | egrep -v '^logfile.000000.out$$|^stdout.out$$|^stderr.out$$|^env.out$$'` > md5sums.txt
+		md5sum `/bin/ls -1d * | egrep -v '^fortran_sha.txt$$|^logfile.000000.out$$|^stdout.out$$|^stderr.out$$|^env.out$$'` > md5sums.txt
 	./check_data_dir.sh $(DATA_DIR_HOST)
 
 pack_data: ## pack *.dat files into a *.tar.gz and delete them


### PR DESCRIPTION
This might not work instantly, since only once the data is pushed to GCP the next time the `fortran_sha.txt` file will be removed.