### PR TITLE
Use long-term-support version of ubuntu

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ SERIALBOX_IMAGE ?= $(GCR_URL)/serialbox-build:$(DEP_TAG_NAME)
 
 # base images w/ or w/o CUDA
 ifeq ($(CUDA),n)
-	BASE_IMAGE ?= ubuntu:19.10
+	BASE_IMAGE ?= ubuntu:20:04
 	DEP_TAG_NAME ?= gnu9-mpich314-nocuda
 else
 	BASE_IMAGE ?= nvidia/cuda:10.2-devel-ubuntu18.04

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ SERIALBOX_IMAGE ?= $(GCR_URL)/serialbox-build:$(DEP_TAG_NAME)
 
 # base images w/ or w/o CUDA
 ifeq ($(CUDA),n)
-	BASE_IMAGE ?= ubuntu:20:04
+	BASE_IMAGE ?= ubuntu:20.04
 	DEP_TAG_NAME ?= gnu9-mpich314-nocuda
 else
 	BASE_IMAGE ?= nvidia/cuda:10.2-devel-ubuntu18.04

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -140,7 +140,7 @@ RUN git clone -b ESMF_8_0_0 --depth 1 https://git.code.sf.net/p/esmf/esmf $ESMF_
 
 ## Copy FV3GFS sources for non-serialize image
 ##---------------------------------------------------------------------------------
-FROM ubuntu:19.10 AS fv3gfs-src-serialize-false
+FROM ubuntu:20.04 AS fv3gfs-src-serialize-false
 
 ARG compile_option
 ARG configure_file=configure.fv3.gnu_docker


### PR DESCRIPTION
Ubuntu 19.10 is not a long term supported release (it is already out of
its 6 month support window).  See this description of Ubuntu's release
process https://ubuntu.com/about/release-cycle.

This PR switches to the latest LTS release (20.04)  which should be
supported for another 4 years. I am open to down-grading to 18.04 for
consistency with the HPC builds.