### PR TITLE
Update example/submit_job.sh for MPICH

### DIFF
--- a/example/submit_job.sh
+++ b/example/submit_job.sh
@@ -5,4 +5,4 @@ RUNDIR=/rundir
 ulimit -s unlimited
 cp /FV3/fv3.exe $RUNDIR/fv3.exe
 cd $RUNDIR
-mpirun -np 6 --allow-run-as-root --mca btl_vader_single_copy_mechanism none --oversubscribe $RUNDIR/fv3.exe
+mpirun -np 6 $RUNDIR/fv3.exe


### PR DESCRIPTION
These flags are no longer needed when using MPICH (as we do now).