### PR TITLE
Fix sea surface temperature cycling

### DIFF
--- a/FV3/gfsphysics/GFS_layer/GFS_physics_driver.F90
+++ b/FV3/gfsphysics/GFS_layer/GFS_physics_driver.F90
@@ -1117,7 +1117,7 @@ module module_physics_driver
         do i = 1, IM
           frland(i) = zero
           if (islmsk(i) == 0) then
-!           Sfcprop%tsfco(i) = Sfcprop%tsfc(i)
+            Sfcprop%tsfco(i) = Sfcprop%tsfc(i)
             wet(i)  = .true.
             fice(i) = zero
           elseif (islmsk(i) == 1) then
@@ -1181,8 +1181,8 @@ module module_physics_driver
       do i=1,im
         if(wet(i)) then                    ! Water
             zorl3(i,3) = Sfcprop%zorlo(i)
-            tsfc3(i,3) = Sfcprop%tsfc(i)
-           tsurf3(i,3) = Sfcprop%tsfc(i)
+            tsfc3(i,3) = Sfcprop%tsfco(i)
+           tsurf3(i,3) = Sfcprop%tsfco(i)
 !          weasd3(i,3) = Sfcprop%weasd(i)
 !          snowd3(i,3) = Sfcprop%snowd(i)
            snowd3(i,3) = zero

--- a/FV3/gfsphysics/GFS_layer/GFS_physics_driver.F90
+++ b/FV3/gfsphysics/GFS_layer/GFS_physics_driver.F90
@@ -1117,7 +1117,7 @@ module module_physics_driver
         do i = 1, IM
           frland(i) = zero
           if (islmsk(i) == 0) then
-!           Sfcprop%tsfco(i) = Sfcprop%tsfc(i)
+            Sfcprop%tsfco(i) = Sfcprop%tsfc(i)
             wet(i)  = .true.
             fice(i) = zero
           elseif (islmsk(i) == 1) then

--- a/FV3/gfsphysics/GFS_layer/GFS_physics_driver.F90
+++ b/FV3/gfsphysics/GFS_layer/GFS_physics_driver.F90
@@ -1117,7 +1117,7 @@ module module_physics_driver
         do i = 1, IM
           frland(i) = zero
           if (islmsk(i) == 0) then
-            Sfcprop%tsfco(i) = Sfcprop%tsfc(i)
+!           Sfcprop%tsfco(i) = Sfcprop%tsfc(i)
             wet(i)  = .true.
             fice(i) = zero
           elseif (islmsk(i) == 1) then
@@ -1181,8 +1181,8 @@ module module_physics_driver
       do i=1,im
         if(wet(i)) then                    ! Water
             zorl3(i,3) = Sfcprop%zorlo(i)
-            tsfc3(i,3) = Sfcprop%tsfco(i)
-           tsurf3(i,3) = Sfcprop%tsfco(i)
+            tsfc3(i,3) = Sfcprop%tsfc(i)
+           tsurf3(i,3) = Sfcprop%tsfc(i)
 !          weasd3(i,3) = Sfcprop%weasd(i)
 !          snowd3(i,3) = Sfcprop%snowd(i)
            snowd3(i,3) = zero


### PR DESCRIPTION
This is the alternative fix mentioned in #92.  This works without having to change the regression test checksums, which we might hope would be the case considering that the regression test only runs for 30 minutes and has a cycling frequency of 24 hours. In theory any change we make here shouldn't change answers, since the model isn't run long enough for cycling to be called.

Tests can be found in [this notebook](https://github.com/VulcanClimateModeling/explore/blob/master/spencerc/2020-10-15-debug-sst/2020-10-15-debug-sst.ipynb).  [EMC seems to think this fix is the correct approach.](https://github.com/NOAA-EMC/fv3atm/issues/79#issuecomment-710353844)