### PR TITLE
Push dep images on every build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,6 +50,7 @@ jobs:
           command: |
             make test
           no_output_timeout: 1200
+      - run: make push_deps
       - run:
           name: "Delete data files"
           command: |

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 # setup (use XXX=<value> make <target> to override)
 GCR_URL ?= us.gcr.io/vcm-ml
+COMMIT_SHA := $(shell git rev-parse HEAD)
 DOCKERFILE ?= docker/Dockerfile
 ENVIRONMENT_TAG_NAME ?= latest
 COMPILE_OPTION ?=
@@ -73,11 +74,13 @@ build_deps: ## build container images of dependnecies (FMS, ESMF, SerialBox)
 	docker build -f $(DOCKERFILE) -t $(ESMF_IMAGE) $(BUILD_ARGS) --target fv3gfs-esmf .
 	docker build -f $(DOCKERFILE) -t $(SERIALBOX_IMAGE) $(BUILD_ARGS) --target fv3gfs-environment-serialbox .
 
-push_deps: ## push container images of dependencies to GCP
-	docker push $(MPI_IMAGE)
-	docker push $(FMS_IMAGE)
-	docker push $(ESMF_IMAGE)
-	docker push $(SERIALBOX_IMAGE)
+push_image_%:
+	docker tag $(GCR_URL)/$*:$(DEP_TAG_NAME) $(GCR_URL)/$*:$(DEP_TAG_NAME)-$(COMMIT_SHA)
+	docker push $(GCR_URL)/$*:$(DEP_TAG_NAME)
+	docker push $(GCR_URL)/$*:$(DEP_TAG_NAME)-$(COMMIT_SHA)
+
+## push container images of dependencies to GCP 
+push_deps: push_image_mpi-build push_image_fms-build push_image_esmf-build push_image-serialbox-build
 
 pull_deps: ## pull container images of dependencies from GCP (for faster builds)
 	docker pull $(MPI_IMAGE)

--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ push_image_%:
 	docker push $(GCR_URL)/$*:$(DEP_TAG_NAME)-$(COMMIT_SHA)
 
 ## push container images of dependencies to GCP 
-push_deps: push_image_mpi-build push_image_fms-build push_image_esmf-build push_image-serialbox-build
+push_deps: push_image_mpi-build push_image_fms-build push_image_esmf-build push_image_serialbox-build
 
 pull_deps: ## pull container images of dependencies from GCP (for faster builds)
 	docker pull $(MPI_IMAGE)


### PR DESCRIPTION
This commit pushes the dependencies images to GCR for every build and
tags by the commit sha. Previously this was only done manually
(presumably from someone's VM).

Resolves #89.