### PR TITLE
Add GOOGLE_APPLICATION_CREDENTIALS to the docker regression test run

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ gcsfs==0.6.2
 fsspec==0.8.0
 f90nml==1.1.0
 google-cloud-storage==1.23.0
-git+https://github.com/VulcanClimateModeling/fv3config.git@db24f18cc8e147866a98159d8efec611d343adc9#egg=fv3config
+git+https://github.com/VulcanClimateModeling/fv3config.git@f498a2a83063fcb2183d511e3d4a5961c8037fd6#egg=fv3config

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 pytest==5.2.2
-gcsfs==0.4.0
-fsspec==0.6.0
+gcsfs==0.6.2
+fsspec==0.8.0
 f90nml==1.1.0
 google-cloud-storage==1.23.0
 git+https://github.com/VulcanClimateModeling/fv3config.git@db24f18cc8e147866a98159d8efec611d343adc9#egg=fv3config

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ gcsfs==0.4.0
 fsspec==0.6.0
 f90nml==1.1.0
 google-cloud-storage==1.23.0
-git+https://github.com/VulcanClimateModeling/fv3config.git@0348a71f1cac9babe82cf23ae5a10c4345ebe14f#egg=fv3config
+git+https://github.com/VulcanClimateModeling/fv3config.git@db24f18cc8e147866a98159d8efec611d343adc9#egg=fv3config

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ gcsfs==0.6.2
 fsspec==0.8.0
 f90nml==1.1.0
 google-cloud-storage==1.23.0
-git+https://github.com/VulcanClimateModeling/fv3config.git@f498a2a83063fcb2183d511e3d4a5961c8037fd6#egg=fv3config
+git+https://github.com/VulcanClimateModeling/fv3config.git@44dfb7c4f8be930316f445ecda2cbea9203c1f1e#egg=fv3config


### PR DESCRIPTION
After flipping the "requester-pays" switch on the public fv3config data the regression tests failed.  This is because the run mechanism through python does not pass the environment variable `GOOGLE_APPLICATION_CREDENTIALS` into the docker image.

Made adjustments to pass those along if the environment var is set.