### PR TITLE
[VCMML-668] Add code to coarsen dynamical core restart files on constant pressure surfaces

### DIFF
--- a/FV3/atmos_cubed_sphere/tools/coarse_grained_restart_files.F90
+++ b/FV3/atmos_cubed_sphere/tools/coarse_grained_restart_files.F90
@@ -522,9 +522,6 @@ contains
  
      allocate(virtual_temp(is_coarse:ie_coarse,js_coarse:je_coarse,1:npz))
      allocate(dlogp(is_coarse:ie_coarse,js_coarse:je_coarse,1:npz))
- 
-     write(*,*) 'sphum minval', minval(sphum)
-     write(*,*) 'sphum maxval', maxval(sphum)
 
      virtual_temp = temp * (1.0 + (RVGAS / RDGAS - 1.0) * sphum)
      do k = 1, npz

--- a/FV3/atmos_cubed_sphere/tools/coarse_grained_restart_files.F90
+++ b/FV3/atmos_cubed_sphere/tools/coarse_grained_restart_files.F90
@@ -319,8 +319,7 @@ contains
 
      ! delp and delz are coarse-grained on model levels; u, v, W, T, and all the tracers
      ! are all remapped to surfaces of constant pressure within coarse grid cells before
-     ! coarse graining.
-
+     ! coarse graining.  At the end, delz and phis are corrected to impose hydrostatic balance.
      call compute_pressure_level_coarse_graining_requirements( &
        Atm, phalf, coarse_phalf, coarse_phalf_on_fine, masked_mass_weights, masked_area_weights)
      call coarse_grain_fv_core_restart_data_on_pressure_levels( &
@@ -518,7 +517,6 @@ contains
      do k = npz, 1, -1
         z_interfaces(:,:,k) = z_interfaces(:,:,k+1) - delz(:,:,k)
      enddo
- 
    end subroutine height_at_interfaces
 
    subroutine hydrostatic_delz(phalf, temp, sphum, delz)
@@ -558,8 +556,6 @@ contains
      real, allocatable :: z_interfaces(:,:,:), top_height(:,:)
      allocate(z_interfaces(is_coarse:ie_coarse,js_coarse:je_coarse,1:npz+1))
      allocate(top_height(is_coarse:ie_coarse,js_coarse:je_coarse))
-
-     sphum = get_tracer_index(MODEL_ATMOS, 'sphum')
 
      call height_at_interfaces(Atm%coarse_graining%restart%delz, Atm%coarse_graining%restart%phis, z_interfaces)
      top_height = z_interfaces(:,:,1)

--- a/FV3/atmos_cubed_sphere/tools/coarse_grained_restart_files.F90
+++ b/FV3/atmos_cubed_sphere/tools/coarse_grained_restart_files.F90
@@ -1,16 +1,17 @@
 module coarse_grained_restart_files_mod
 
   use coarse_graining_mod, only: compute_mass_weights, get_coarse_array_bounds,&
-       get_fine_array_bounds, MODEL_LEVEL, weighted_block_average, &
+       get_fine_array_bounds, MODEL_LEVEL, PRESSURE_LEVEL, weighted_block_average, &
        weighted_block_edge_average_x, weighted_block_edge_average_y, &
        mask_area_weights, mask_mass_weights, block_upsample, remap_edges_along_x, &
-       remap_edges_along_y
+       remap_edges_along_y, vertically_remap_field
+  use constants_mod, only: GRAV, RDGAS, RVGAS
   use field_manager_mod, only: MODEL_ATMOS
   use fms_io_mod,      only: register_restart_field, save_restart
   use fv_arrays_mod, only: coarse_restart_type, fv_atmos_type
   use mpp_domains_mod, only: domain2d, EAST, NORTH, mpp_update_domains
   use mpp_mod, only: FATAL, mpp_error
-  use tracer_manager_mod, only: get_tracer_names, set_tracer_profile
+  use tracer_manager_mod, only: get_tracer_names, get_tracer_index, set_tracer_profile
 
   implicit none
   private
@@ -279,8 +280,10 @@ contains
 
     if (trim(Atm%coarse_graining%strategy) .eq. MODEL_LEVEL) then
        call coarse_grain_restart_data_on_model_levels(Atm)
+    elseif (trim(Atm%coarse_graining%strategy) .eq. PRESSURE_LEVEL) then
+       call coarse_grain_restart_data_on_pressure_levels(Atm)
     else
-       write(error_message, *) 'Currently only model_level coarse-graining is supported for restart files.'
+       write(error_message, *) 'Currently only model_level and pressure_level coarse-graining are supported for restart files.'
        call mpp_error(FATAL, error_message)
     endif
   end subroutine coarse_grain_restart_data
@@ -295,10 +298,10 @@ contains
 
     call coarse_grain_fv_core_restart_data_on_model_levels(Atm, mass)
     call coarse_grain_fv_tracer_restart_data_on_model_levels(Atm, mass)
-    call coarse_grain_fv_srf_wnd_restart_data_on_model_levels(Atm)
+    call coarse_grain_fv_srf_wnd_restart_data(Atm)
     if (Atm%flagstruct%fv_land) then
-       call coarse_grain_mg_drag_restart_data_on_model_levels(Atm)
-       call coarse_grain_fv_land_restart_data_on_model_levels(Atm)
+       call coarse_grain_mg_drag_restart_data(Atm)
+       call coarse_grain_fv_land_restart_data(Atm)
     endif
   end subroutine coarse_grain_restart_data_on_model_levels
 
@@ -322,7 +325,14 @@ contains
        Atm, phalf, coarse_phalf, coarse_phalf_on_fine, masked_mass_weights, masked_area_weights)
      call coarse_grain_fv_core_restart_data_on_pressure_levels( &
        Atm, phalf, coarse_phalf, coarse_phalf_on_fine, masked_mass_weights, masked_area_weights)
-
+     call coarse_grain_fv_tracer_restart_data_on_pressure_levels( &
+       Atm, phalf, coarse_phalf_on_fine, masked_mass_weights, masked_area_weights)
+     call coarse_grain_fv_srf_wnd_restart_data(Atm)
+     if (Atm%flagstruct%fv_land) then
+       call coarse_grain_mg_drag_restart_data(Atm)
+       call coarse_grain_fv_land_restart_data(Atm)
+     endif
+     call impose_hydrostatic_balance(Atm, coarse_phalf)
   end subroutine coarse_grain_restart_data_on_pressure_levels
 
   subroutine coarse_grain_fv_core_restart_data_on_model_levels(Atm, mass)
@@ -389,28 +399,28 @@ contains
     enddo
   end subroutine coarse_grain_fv_tracer_restart_data_on_model_levels
 
-  subroutine coarse_grain_fv_srf_wnd_restart_data_on_model_levels(Atm)
+  subroutine coarse_grain_fv_srf_wnd_restart_data(Atm)
     type(fv_atmos_type), intent(inout) :: Atm
 
     call weighted_block_average(Atm%gridstruct%area(is:ie,js:je), &
          Atm%u_srf(is:ie,js:je), Atm%coarse_graining%restart%u_srf)
     call weighted_block_average(Atm%gridstruct%area(is:ie,js:je), &
          Atm%v_srf(is:ie,js:je), Atm%coarse_graining%restart%v_srf)
-  end subroutine coarse_grain_fv_srf_wnd_restart_data_on_model_levels
+  end subroutine coarse_grain_fv_srf_wnd_restart_data
 
-  subroutine coarse_grain_mg_drag_restart_data_on_model_levels(Atm)
+  subroutine coarse_grain_mg_drag_restart_data(Atm)
     type(fv_atmos_type), intent(inout) :: Atm
 
     call weighted_block_average(Atm%gridstruct%area(is:ie,js:je), &
          Atm%sgh(is:ie,js:je), Atm%coarse_graining%restart%sgh)
-  end subroutine coarse_grain_mg_drag_restart_data_on_model_levels
+  end subroutine coarse_grain_mg_drag_restart_data
 
-  subroutine coarse_grain_fv_land_restart_data_on_model_levels(Atm)
+  subroutine coarse_grain_fv_land_restart_data(Atm)
     type(fv_atmos_type), intent(inout) :: Atm
 
     call weighted_block_average(Atm%gridstruct%area(is:ie,js:je), &
          Atm%oro(is:ie,js:je), Atm%coarse_graining%restart%oro)
-  end subroutine coarse_grain_fv_land_restart_data_on_model_levels
+  end subroutine coarse_grain_fv_land_restart_data
 
   subroutine coarse_grain_fv_core_restart_data_on_pressure_levels(& 
      Atm, phalf, coarse_phalf, coarse_phalf_on_fine, masked_mass_weights, masked_area_weights)
@@ -457,7 +467,107 @@ contains
      endif
   end subroutine coarse_grain_fv_core_restart_data_on_pressure_levels
 
-  subroutine compute_pressure_level_coarse_graining_requirements(&
+  subroutine coarse_grain_fv_tracer_restart_data_on_pressure_levels( &
+     Atm, phalf, coarse_phalf_on_fine, masked_mass_weights, masked_area_weights)
+     type(fv_atmos_type), intent(inout) :: Atm
+     real, intent(in) :: phalf(is-1:ie+1,js-1:je+1,1:npz+1)
+     real, intent(in) :: coarse_phalf_on_fine(is:ie,js:je,1:npz+1)
+     real, intent(in), dimension(is:ie,js:je,1:npz) :: masked_mass_weights, masked_area_weights
+
+     real, allocatable :: remapped(:,:,:)
+     character(len=64) :: tracer_name
+     integer :: n_tracer
+ 
+     allocate(remapped(is:ie,js:je,1:npz))
+
+     do n_tracer = 1, n_prognostic_tracers
+       call get_tracer_names(MODEL_ATMOS, n_tracer, tracer_name)
+       call vertically_remap_field(phalf(is:ie,js:je,1:npz+1), &
+         Atm%q(is:ie,js:je,1:npz,n_tracer), coarse_phalf_on_fine, Atm%ptop, remapped)
+       if (trim(tracer_name) .eq. 'cld_amt') then
+         call weighted_block_average(masked_area_weights, &
+           remapped, &
+           Atm%coarse_graining%restart%q(is_coarse:ie_coarse,js_coarse:je_coarse,1:npz,n_tracer))
+       else
+         call weighted_block_average(masked_mass_weights, &
+           remapped, &
+           Atm%coarse_graining%restart%q(is_coarse:ie_coarse,js_coarse:je_coarse,1:npz,n_tracer))
+       endif
+     enddo
+ 
+     do n_tracer = n_prognostic_tracers + 1, n_tracers
+       call vertically_remap_field(phalf(is:ie,js:je,1:npz+1), &
+         Atm%qdiag(is:ie,js:je,1:npz,n_tracer), coarse_phalf_on_fine, Atm%ptop, remapped)
+       call weighted_block_average(masked_mass_weights, &
+         remapped, &
+         Atm%coarse_graining%restart%qdiag(is_coarse:ie_coarse,js_coarse:je_coarse,1:npz,n_tracer))
+     enddo
+   end subroutine coarse_grain_fv_tracer_restart_data_on_pressure_levels
+
+  ! Compute the height at model interfaces by integrating upward from phis; all
+  ! inputs and outputs are already coarse-grained here.
+   subroutine height_at_interfaces(delz, phis, z_interfaces)
+     real, intent(in) :: delz(is_coarse:ie_coarse,js_coarse:je_coarse,1:npz)
+     real, intent(in) :: phis(is_coarse:ie_coarse,js_coarse:je_coarse)
+     real, intent(out) :: z_interfaces(is_coarse:ie_coarse,js_coarse:je_coarse,1:npz+1)
+ 
+     integer :: k
+ 
+     z_interfaces(:,:,npz+1) = phis / GRAV
+ 
+     do k = npz, 1, -1
+        z_interfaces(:,:,k) = z_interfaces(:,:,k+1) - delz(:,:,k)
+     enddo
+ 
+   end subroutine height_at_interfaces
+
+   subroutine hydrostatic_delz(phalf, temp, sphum, delz)
+     real, intent(in) :: phalf(is_coarse:ie_coarse,js_coarse:je_coarse,1:npz+1)
+     real, intent(in) :: temp(is_coarse:ie_coarse,js_coarse:je_coarse,1:npz)
+     real, intent(in) :: sphum(is_coarse:ie_coarse,js_coarse:je_coarse,1:npz)
+     real, intent(out) :: delz(is_coarse:ie_coarse,js_coarse:je_coarse,1:npz)
+ 
+     real, allocatable :: virtual_temp(:,:,:), dlogp(:,:,:)
+     integer :: k
+ 
+     allocate(virtual_temp(is_coarse:ie_coarse,js_coarse:je_coarse,1:npz))
+     allocate(dlogp(is_coarse:ie_coarse,js_coarse:je_coarse,1:npz))
+ 
+     virtual_temp = temp * (1.0 + (RVGAS / RDGAS - 1.0) * sphum)
+     do k = 1, npz
+        dlogp(:,:,k) = log(phalf(:,:,k+1)) - log(phalf(:,:,k))
+     enddo
+     delz = -dlogp * RDGAS * virtual_temp / GRAV
+   end subroutine hydrostatic_delz
+
+  ! Compute surface geopotential from model top height and layer thicknesses.
+   subroutine delz_and_top_height_to_phis(top_height, delz, phis)
+     real, intent(in) :: top_height(is_coarse:ie_coarse,js_coarse:je_coarse)
+     real, intent(in) :: delz(is_coarse:ie_coarse,js_coarse:je_coarse,1:npz)
+     real, intent(out) :: phis(is_coarse:ie_coarse,js_coarse:je_coarse)
+ 
+     phis = GRAV * (top_height + sum(delz, dim=3))
+   end subroutine delz_and_top_height_to_phis
+
+   subroutine impose_hydrostatic_balance(Atm, coarse_phalf)
+     type(fv_atmos_type), intent(inout) :: Atm
+     real, intent(in) :: coarse_phalf(is_coarse:ie_coarse,js_coarse:je_coarse,1:npz+1)
+
+     integer :: sphum
+
+     real, allocatable :: z_interfaces(:,:,:), top_height(:,:)
+     allocate(z_interfaces(is_coarse:ie_coarse,js_coarse:je_coarse,1:npz+1))
+     allocate(top_height(is_coarse:ie_coarse,js_coarse:je_coarse))
+
+     sphum = get_tracer_index(MODEL_ATMOS, 'sphum')
+
+     call height_at_interfaces(Atm%coarse_graining%restart%delz, Atm%coarse_graining%restart%phis, z_interfaces)
+     top_height = z_interfaces(:,:,1)
+     call hydrostatic_delz(coarse_phalf, Atm%coarse_graining%restart%pt, Atm%coarse_graining%restart%q(is_coarse:ie_coarse,js_coarse:je_coarse,1:npz,sphum), Atm%coarse_graining%restart%delz)
+     call delz_and_top_height_to_phis(top_height, Atm%coarse_graining%restart%delz, Atm%coarse_graining%restart%phis)
+   end subroutine impose_hydrostatic_balance
+
+  subroutine compute_pressure_level_coarse_graining_requirements( &
      Atm, phalf, coarse_phalf, coarse_phalf_on_fine, masked_mass_weights, masked_area_weights)
      type(fv_atmos_type), intent(inout) :: Atm
      real, intent(out) :: phalf(is-1:ie+1,js-1:je+1,1:npz+1)
@@ -468,17 +578,19 @@ contains
      ! Do a halo update on delp before proceeding here, because the remapping procedure
      ! for the winds requires interpolating across tile edges.
      call mpp_update_domains(Atm%delp, Atm%domain, complete=.true.)
-     call compute_phalf_with_halo(Atm%delp(is-1:ie+1,js-1:je+1,1:npz), Atm%ptop, phalf)
-     call weighted_block_average(Atm%gridstruct%area(is:ie,js:je), Atm%delp(is:ie,js:je,1:npz), coarse_phalf)
+     call compute_phalf(is - 1, ie + 1, js - 1, je + 1, Atm%delp(is-1:ie+1,js-1:je+1,1:npz), Atm%ptop, phalf)
+     call weighted_block_average(Atm%gridstruct%area(is:ie,js:je), Atm%delp(is:ie,js:je,1:npz), Atm%coarse_graining%restart%delp)
+     call compute_phalf(is_coarse, ie_coarse, js_coarse, je_coarse, Atm%coarse_graining%restart%delp, Atm%ptop, coarse_phalf)
      call block_upsample(coarse_phalf, coarse_phalf_on_fine, npz+1)
      call mask_mass_weights(Atm%gridstruct%area(is:ie,js:je), Atm%delp(is:ie,js:je,1:npz), phalf(is:ie,js:je,1:npz+1), coarse_phalf_on_fine, masked_mass_weights)
      call mask_area_weights(Atm%gridstruct%area(is:ie,js:je), phalf(is:ie,js:je,1:npz+1), coarse_phalf_on_fine, masked_area_weights)
   end subroutine compute_pressure_level_coarse_graining_requirements
 
-  subroutine compute_phalf_with_halo(delp, ptop, phalf)
-     real, intent(in) :: delp(is-1:ie+1,js-1:je+1,1:npz)
+  subroutine compute_phalf(i_start, i_end, j_start, j_end, delp, ptop, phalf)
+     integer, intent(in) :: i_start, i_end, j_start, j_end
+     real, intent(in) :: delp(i_start:i_end,j_start:j_end,1:npz)
      real, intent(in) :: ptop
-     real, intent(out) :: phalf(is-1:ie+1,js-1:je+1,1:npz+1)
+     real, intent(out) :: phalf(i_start:i_end,j_start:j_end,1:npz+1)
 
      integer :: k
 
@@ -486,5 +598,5 @@ contains
      do k = 2, npz + 1
        phalf(:,:,k) = phalf(:,:,k-1) + delp(:,:,k-1)
      enddo
-  end subroutine compute_phalf_with_halo
+  end subroutine compute_phalf
 end module coarse_grained_restart_files_mod

--- a/FV3/coarse_graining/coarse_graining.F90
+++ b/FV3/coarse_graining/coarse_graining.F90
@@ -780,7 +780,7 @@ contains
 
   subroutine remap_edges_along_y(field, phalf, dy, ptop, result)
     real, intent(in) :: field(is:ie+1,js:je,1:npz)
-    real, intent(in) :: phalf(is-1,ie+1,js-1,je+1,1:npz+1)
+    real, intent(in) :: phalf(is-1:ie+1,js-1:je+1,1:npz+1)
     real, intent(in) :: dy(is:ie+1,js:je)
     real, intent(in) :: ptop
     real, intent(out) :: result(is_coarse:ie_coarse+1,js_coarse:je_coarse,1:npz)
@@ -793,7 +793,7 @@ contains
     allocate(phalf_d_grid(is_coarse:ie_coarse+1,js:je,1:npz+1))
     allocate(coarse_phalf_d_grid(is_coarse:ie_coarse+1,js_coarse:je_coarse,1:npz+1))
     allocate(coarse_phalf_d_grid_on_fine(is_coarse:ie_coarse+1,js:je,1:npz+1))
-    allocate(remapped(is_coarse:ie_coarse+1,js:je+1,1:npz))
+    allocate(remapped(is_coarse:ie_coarse+1,js:je,1:npz))
     allocate(mask(is_coarse:ie_coarse+1,js:je,1:npz))
 
     ! Hard-code parameters related to mappm.
@@ -812,7 +812,7 @@ contains
     call upsample_d_grid_y(coarse_phalf_d_grid, coarse_phalf_d_grid_on_fine, npz+1)
 
     do i = is, ie + 1, coarsening_factor
-      i_coarse = (j - 1) / coarsening_factor + 1
+      i_coarse = (i - 1) / coarsening_factor + 1
       call mappm(km, phalf_d_grid(i_coarse,js:je,:), field(i,js:je,:), kn, &
         coarse_phalf_d_grid_on_fine(i_coarse,js:je,:), &
         remapped(i_coarse,js:je,:), js, je, iv, kord, ptop)

--- a/FV3/coarse_graining/coarse_graining.F90
+++ b/FV3/coarse_graining/coarse_graining.F90
@@ -545,7 +545,7 @@ contains
    ! A naive routine for interpolating a field from the A-grid to the y-boundary
    ! of the D-grid; this is a specialized function that automatically
    ! downsamples to the coarse-grid on the downsampling dimension.
-   subroutine a_grid_to_d_grid_y(field_in, field_out, nz)
+   subroutine interpolate_to_d_grid_and_downsample_along_y(field_in, field_out, nz)
     integer, intent(in) :: nz
     real, intent(in) :: field_in(is-1:ie+1,js-1:je+1,1:nz)
     real, intent(out) :: field_out(is:ie,js_coarse:je_coarse+1,1:nz)
@@ -560,7 +560,7 @@ contains
           enddo
        enddo
     enddo
-   end subroutine a_grid_to_d_grid_y
+   end subroutine interpolate_to_d_grid_and_downsample_along_y
 
    subroutine weighted_block_edge_average_x_pre_downsampled_unmasked(fine, dx, coarse, nz)
     integer, intent(in) :: nz
@@ -658,7 +658,7 @@ contains
     iv = 1
 
     ! 1. Interpolate and downsample phalf
-    call a_grid_to_d_grid_y(phalf, phalf_d_grid, npz+1)  ! TODO: better name for subroutine
+    call interpolate_to_d_grid_and_downsample_along_y(phalf, phalf_d_grid, npz+1)
 
     ! 2. Coarsen phalf on the D-grid
     call weighted_block_edge_average_x_pre_downsampled(phalf_d_grid, dx, coarse_phalf_d_grid, npz+1)
@@ -689,7 +689,7 @@ contains
   ! A naive routine for interpolating a field from the A-grid to the x-boundary
   ! of the D-grid; this is a specialized function that automatically
   ! downsamples to the coarse-grid on the downsampling dimension.
-  subroutine a_grid_to_d_grid_x(field_in, field_out, nz)
+  subroutine interpolate_to_d_grid_and_downsample_along_x(field_in, field_out, nz)
     integer, intent(in) :: nz
     real, intent(in) :: field_in(is-1:ie+1,js-1:je+1,1:nz)
     real, intent(out) :: field_out(is_coarse:ie_coarse+1,js:je,1:nz)
@@ -704,7 +704,7 @@ contains
           enddo
        enddo
     enddo
-  end subroutine a_grid_to_d_grid_x
+  end subroutine interpolate_to_d_grid_and_downsample_along_x
 
   subroutine weighted_block_edge_average_y_pre_downsampled_unmasked(fine, dy, coarse, nz)
     integer, intent(in) :: nz
@@ -803,7 +803,7 @@ contains
     iv = 1
 
     ! 1. Interpolate and downsample phalf
-    call a_grid_to_d_grid_x(phalf, phalf_d_grid, npz+1)  ! TODO: better name for subroutine
+    call interpolate_to_d_grid_and_downsample_along_x(phalf, phalf_d_grid, npz+1)
 
     ! 2. Coarsen phalf on the D-grid
     call weighted_block_edge_average_y_pre_downsampled(phalf_d_grid, dy, coarse_phalf_d_grid, npz+1)

--- a/FV3/coarse_graining/coarse_graining.F90
+++ b/FV3/coarse_graining/coarse_graining.F90
@@ -12,7 +12,7 @@ module coarse_graining_mod
        get_coarse_array_bounds, coarse_graining_init, weighted_block_average, &
        weighted_block_edge_average_x, weighted_block_edge_average_y, MODEL_LEVEL, &
        block_upsample, mask_area_weights, PRESSURE_LEVEL, vertical_remapping_requirements, &
-       vertically_remap_field
+       vertically_remap_field, mask_mass_weights, remap_edges_along_x, remap_edges_along_y
 
   interface block_sum
      module procedure block_sum_2d
@@ -38,6 +38,16 @@ module coarse_graining_mod
      module procedure block_upsample_2d
      module procedure block_upsample_3d
   end interface block_upsample
+
+  interface weighted_block_edge_average_x_pre_downsampled
+     module procedure weighted_block_edge_average_x_pre_downsampled_unmasked
+     module procedure weighted_block_edge_average_x_pre_downsampled_masked
+  end interface weighted_block_edge_average_x_pre_downsampled
+
+  interface weighted_block_edge_average_y_pre_downsampled
+     module procedure weighted_block_edge_average_y_pre_downsampled_unmasked
+     module procedure weighted_block_edge_average_y_pre_downsampled_masked
+  end interface weighted_block_edge_average_y_pre_downsampled
 
   ! Global variables for the module, initialized in coarse_graining_init
   integer :: is, ie, js, je, npz
@@ -349,12 +359,12 @@ contains
 
   subroutine block_upsample_3d(coarse, fine, nz)
     integer, intent(in) :: nz
-    real, intent(in) :: coarse(is_coarse:ie_coarse,js_coarse:je_coarse,1:nz+1)
-    real, intent(out) :: fine(is:ie,js:je,1:nz+1)
+    real, intent(in) :: coarse(is_coarse:ie_coarse,js_coarse:je_coarse,1:nz)
+    real, intent(out) :: fine(is:ie,js:je,1:nz)
 
     integer :: k
 
-    do k = 1, nz + 1
+    do k = 1, nz
       call block_upsample_2d(coarse(is_coarse:ie_coarse,js_coarse:je_coarse,k), fine(is:ie,js:je,k))
     enddo
   end subroutine block_upsample_3d
@@ -513,4 +523,311 @@ contains
     enddo
    end subroutine mask_area_weights
 
+   subroutine mask_mass_weights(area, delp, phalf, upsampled_coarse_phalf, &
+    masked_mass_weights)
+    real, intent(in) :: area(is:ie,js:je)
+    real, intent(in) :: delp(is:ie,js:je,1:npz)
+    real, intent(in) :: phalf(is:ie,js:je,1:npz+1)
+    real, intent(in) :: upsampled_coarse_phalf(is:ie,js:je,1:npz+1)
+    real, intent(out) :: masked_mass_weights(is:ie,js:je,1:npz)
+
+    integer :: k
+
+    do k = 1, npz
+      where (upsampled_coarse_phalf(:,:,k+1) .lt. phalf(is:ie,js:je,npz+1))
+        masked_mass_weights(:,:,k) = delp(:,:,k) * area(:,:)
+      elsewhere
+        masked_mass_weights(:,:,k) = 0.0
+      endwhere
+    enddo
+   end subroutine mask_mass_weights
+
+   ! A naive routine for interpolating a field from the A-grid to the y-boundary
+   ! of the D-grid; this is a specialized function that automatically
+   ! downsamples to the coarse-grid on the downsampling dimension.
+   subroutine a_grid_to_d_grid_y(field_in, field_out, nz)
+    integer, intent(in) :: nz
+    real, intent(in) :: field_in(is-1:ie+1,js-1:je+1,1:nz)
+    real, intent(out) :: field_out(is:ie,js_coarse:je_coarse+1,1:nz)
+
+    integer :: i, j, k, j_coarse
+
+    do i = is,ie
+       do j = js,je+1,coarsening_factor
+          j_coarse = (j - 1) / coarsening_factor + 1
+          do k = 1,nz
+             field_out(i,j_coarse,k) = 0.5 * (field_in(i,j,k) + field_in(i,j-1,k))
+          enddo
+       enddo
+    enddo
+   end subroutine a_grid_to_d_grid_y
+
+   subroutine weighted_block_edge_average_x_pre_downsampled_unmasked(fine, dx, coarse, nz)
+    integer, intent(in) :: nz
+    real, intent(in) :: fine(is:ie,js_coarse:je_coarse+1,1:nz)
+    real, intent(in) :: dx(is:ie,js:je+1)
+    real, intent(out) :: coarse(is_coarse:ie_coarse,js_coarse:je_coarse+1,1:nz)
+
+    integer :: i, j, k, a, i_coarse, j_coarse
+
+    a = coarsening_factor - 1
+    do k = 1, nz
+        do i = is, ie, coarsening_factor
+          i_coarse = (i - 1) / coarsening_factor + 1
+          do j = js, je + 1, coarsening_factor
+              j_coarse = (j - 1) / coarsening_factor + 1
+              coarse(i_coarse,j_coarse,k) = sum(dx(i:i+a,j) * fine(i:i+a,j_coarse,k)) / sum(dx(i:i+a,j))
+          enddo
+        enddo
+    enddo
+   end subroutine weighted_block_edge_average_x_pre_downsampled_unmasked
+
+   subroutine weighted_block_edge_average_x_pre_downsampled_masked(fine, dx,&
+    coarse, mask, nz)
+    integer, intent(in) :: nz
+    real, intent(in) :: fine(is:ie,js_coarse:je_coarse+1,1:nz)
+    real, intent(in) :: dx(is:ie,js:je+1)
+    logical, intent(in) :: mask(is:ie,js_coarse:je_coarse+1,1:nz)
+    real, intent(out) :: coarse(is_coarse:ie_coarse,js_coarse:je_coarse+1,1:nz)
+
+    real, allocatable :: weights(:,:), downsampled_dx(:,:)
+
+    integer :: i, j, k, a, i_coarse, j_coarse
+
+    allocate(weights(is:ie,js_coarse:je_coarse+1))
+    allocate(downsampled_dx(is:ie,js_coarse:je_coarse+1))
+
+    downsampled_dx = dx(:,js:je+1:coarsening_factor)
+
+    a = coarsening_factor - 1
+    do k = 1, nz
+        where (mask(:,:,k))
+          weights = downsampled_dx
+        elsewhere
+          weights = 0.0
+        endwhere
+        do i = is, ie, coarsening_factor
+          i_coarse = (i - 1) / coarsening_factor + 1
+          do j = js, je + 1, coarsening_factor
+              j_coarse = (j - 1) / coarsening_factor + 1
+              coarse(i_coarse,j_coarse,k) = sum(weights(i:i+a,j_coarse) * fine(i:i+a,j_coarse,k)) / sum(weights(i:i+a,j_coarse))
+          enddo
+        enddo
+    enddo
+   end subroutine weighted_block_edge_average_x_pre_downsampled_masked
+
+   subroutine upsample_d_grid_x(field_in, field_out, nz)
+    integer, intent(in) :: nz
+    real, intent(in) :: field_in(is_coarse:ie_coarse,js_coarse:je_coarse+1,1:nz)
+    real, intent(out) :: field_out(is:ie,js_coarse:je_coarse+1,1:nz)
+
+    integer :: i, j, k, a, i_coarse
+    a = coarsening_factor - 1
+    do i = is, ie, coarsening_factor
+       i_coarse = (i - 1) / coarsening_factor + 1
+       do j = js_coarse, je_coarse + 1
+          do k = 1, nz
+             field_out(i:i+a,j,k) = field_in(i_coarse,j,k)
+          enddo
+       enddo
+    enddo
+   end subroutine upsample_d_grid_x
+
+   subroutine remap_edges_along_x(field, phalf, dx, ptop, result)
+    real, intent(in) :: field(is:ie,js:je+1,1:npz)
+    real, intent(in) :: phalf(is-1,ie+1,js-1,je+1,1:npz+1)
+    real, intent(in) :: dx(is:ie,js:je+1)
+    real, intent(in) :: ptop
+    real, intent(out) :: result(is_coarse:ie_coarse,js_coarse:je_coarse+1,1:npz)
+
+    real, allocatable, dimension(:,:,:) :: phalf_d_grid, coarse_phalf_d_grid, coarse_phalf_d_grid_on_fine, remapped
+    logical, allocatable :: mask(:,:,:)
+
+    integer :: i, i_coarse, j, j_coarse, k, kn, km, kord, iv
+
+    allocate(phalf_d_grid(is:ie,js_coarse:je_coarse+1,1:npz+1))
+    allocate(coarse_phalf_d_grid(is_coarse:ie_coarse,js_coarse:je_coarse+1,1:npz+1))
+    allocate(coarse_phalf_d_grid_on_fine(is:ie,js_coarse:je_coarse+1,1:npz+1))
+    allocate(remapped(is:ie,js_coarse:je_coarse+1,1:npz))
+    allocate(mask(is:ie,js_coarse:je_coarse+1,1:npz))
+
+    ! Hard-code parameters related to mappm.
+    kn = npz
+    km = npz
+    kord = 1
+    iv = 1
+
+    ! 1. Interpolate and downsample phalf
+    call a_grid_to_d_grid_y(phalf, phalf_d_grid, npz+1)  ! TODO: better name for subroutine
+
+    ! 2. Coarsen phalf on the D-grid
+    call weighted_block_edge_average_x_pre_downsampled(phalf_d_grid, dx, coarse_phalf_d_grid, npz+1)
+
+    ! 3. Upsample coarsened phalf back to the original resolution
+    call upsample_d_grid_x(coarse_phalf_d_grid, coarse_phalf_d_grid_on_fine, npz+1)
+
+    do j = js, je + 1, coarsening_factor
+      j_coarse = (j - 1) / coarsening_factor + 1
+      call mappm(km, phalf_d_grid(is:ie,j_coarse,:), field(is:ie,j,:), kn, &
+        coarse_phalf_d_grid_on_fine(is:ie,j_coarse,:), &
+        remapped(is:ie,j_coarse,:), is, ie, iv, kord, ptop)
+    enddo
+
+    ! 5. Create mask
+    do k = 1, npz
+      where (coarse_phalf_d_grid_on_fine(:,:,k+1) .lt. phalf_d_grid(:,:,npz+1))
+        mask(:,:,k) = .true.
+      elsewhere
+        mask(:,:,k) = .false.
+      endwhere
+    enddo
+
+    ! 6. Coarsen the remapped field
+    call weighted_block_edge_average_x_pre_downsampled(remapped, dx, result, mask, npz)
+  end subroutine remap_edges_along_x
+
+  ! A naive routine for interpolating a field from the A-grid to the x-boundary
+  ! of the D-grid; this is a specialized function that automatically
+  ! downsamples to the coarse-grid on the downsampling dimension.
+  subroutine a_grid_to_d_grid_x(field_in, field_out, nz)
+    integer, intent(in) :: nz
+    real, intent(in) :: field_in(is-1:ie+1,js-1:je+1,1:nz)
+    real, intent(out) :: field_out(is_coarse:ie_coarse+1,js:je,1:nz)
+
+    integer :: i, j, k, i_coarse
+
+    do i = is,ie+1,coarsening_factor
+       i_coarse = (i - 1) / coarsening_factor + 1
+       do j = js,je
+          do k = 1,nz
+             field_out(i_coarse,j,k) = 0.5 * (field_in(i,j,k) + field_in(i-1,j,k))
+          enddo
+       enddo
+    enddo
+  end subroutine a_grid_to_d_grid_x
+
+  subroutine weighted_block_edge_average_y_pre_downsampled_unmasked(fine, dy, coarse, nz)
+    integer, intent(in) :: nz
+    real, intent(in) :: fine(is_coarse:ie_coarse+1,js:je,1:nz)
+    real, intent(in) :: dy(is:ie+1,js:je)
+    real, intent(out) :: coarse(is_coarse:ie_coarse+1,js_coarse:je_coarse,1:nz)
+
+    integer :: i, j, k, a, i_coarse, j_coarse
+
+    a = coarsening_factor - 1
+    do k = 1, nz
+       do i = is, ie + 1, coarsening_factor
+          i_coarse = (i - 1) / coarsening_factor + 1
+          do j = js, je, coarsening_factor
+             j_coarse = (j - 1) / coarsening_factor + 1
+             coarse(i_coarse,j_coarse,k) = sum(dy(i,j:j+a) * fine(i_coarse,j:j+a,k)) / sum(dy(i,j:j+a))
+          enddo
+       enddo
+    enddo
+  end subroutine weighted_block_edge_average_y_pre_downsampled_unmasked
+
+  subroutine weighted_block_edge_average_y_pre_downsampled_masked(fine, dy,&
+    coarse, mask, nz)
+    integer, intent(in) :: nz
+    real, intent(in) :: fine(is_coarse:ie_coarse+1,js:je,1:nz)
+    real, intent(in) :: dy(is:ie+1,js:je)
+    logical, intent(in) :: mask(is_coarse:ie_coarse+1,js:je,1:nz)
+    real, intent(out) :: coarse(is_coarse:ie_coarse+1,js_coarse:je_coarse,1:nz)
+
+    real, allocatable :: weights(:,:), downsampled_dy(:,:)
+
+    integer :: i, j, k, a, i_coarse, j_coarse
+
+
+    allocate(weights(is_coarse:ie_coarse+1,js:je))
+    allocate(downsampled_dy(is_coarse:ie_coarse+1,js:je))
+
+    downsampled_dy = dy(is:ie+1:coarsening_factor,:)
+
+    a = coarsening_factor - 1
+    do k = 1, nz
+        where (mask(:,:,k))
+          weights = downsampled_dy
+        elsewhere
+          weights = 0.0
+        endwhere
+        do i = is, ie + 1, coarsening_factor
+          i_coarse = (i - 1) / coarsening_factor + 1
+          do j = js, je, coarsening_factor
+              j_coarse = (j - 1) / coarsening_factor + 1
+              coarse(i_coarse,j_coarse,k) = sum(weights(i_coarse,j:j+a) * fine(i_coarse,j:j+a,k)) / sum(weights(i_coarse,j:j+a))
+          enddo
+        enddo
+    enddo
+  end subroutine weighted_block_edge_average_y_pre_downsampled_masked
+
+  subroutine upsample_d_grid_y(field_in, field_out, nz)
+    integer, intent(in) :: nz
+    real, intent(in) :: field_in(is_coarse:ie_coarse+1,js_coarse:je_coarse,1:nz)
+    real, intent(out) :: field_out(is_coarse:ie_coarse+1,js:je,1:nz)
+
+    integer :: i, j, k, a, j_coarse
+    a = coarsening_factor - 1
+    do i = is_coarse, ie_coarse + 1
+       do j = js,je,coarsening_factor
+          j_coarse = (j - 1) / coarsening_factor + 1
+          do k = 1, nz
+             field_out(i,j:j+a,k) = field_in(i,j_coarse,k)
+          enddo
+       enddo
+    enddo
+  end subroutine upsample_d_grid_y
+
+  subroutine remap_edges_along_y(field, phalf, dy, ptop, result)
+    real, intent(in) :: field(is:ie+1,js:je,1:npz)
+    real, intent(in) :: phalf(is-1,ie+1,js-1,je+1,1:npz+1)
+    real, intent(in) :: dy(is:ie+1,js:je)
+    real, intent(in) :: ptop
+    real, intent(out) :: result(is_coarse:ie_coarse+1,js_coarse:je_coarse,1:npz)
+
+    real, allocatable, dimension(:,:,:) :: phalf_d_grid, coarse_phalf_d_grid, coarse_phalf_d_grid_on_fine, remapped
+    logical, allocatable :: mask(:,:,:)
+
+    integer :: i, i_coarse, j, j_coarse, k, kn, km, kord, iv
+
+    allocate(phalf_d_grid(is_coarse:ie_coarse+1,js:je,1:npz+1))
+    allocate(coarse_phalf_d_grid(is_coarse:ie_coarse+1,js_coarse:je_coarse,1:npz+1))
+    allocate(coarse_phalf_d_grid_on_fine(is_coarse:ie_coarse+1,js:je,1:npz+1))
+    allocate(remapped(is_coarse:ie_coarse+1,js:je+1,1:npz))
+    allocate(mask(is_coarse:ie_coarse+1,js:je,1:npz))
+
+    ! Hard-code parameters related to mappm.
+    kn = npz
+    km = npz
+    kord = 1
+    iv = 1
+
+    ! 1. Interpolate and downsample phalf
+    call a_grid_to_d_grid_x(phalf, phalf_d_grid, npz+1)  ! TODO: better name for subroutine
+
+    ! 2. Coarsen phalf on the D-grid
+    call weighted_block_edge_average_y_pre_downsampled(phalf_d_grid, dy, coarse_phalf_d_grid, npz+1)
+
+    ! 3. Upsample coarsened phalf back to the original resolution
+    call upsample_d_grid_y(coarse_phalf_d_grid, coarse_phalf_d_grid_on_fine, npz+1)
+
+    do i = is, ie + 1, coarsening_factor
+      i_coarse = (j - 1) / coarsening_factor + 1
+      call mappm(km, phalf_d_grid(i_coarse,js:je,:), field(i,js:je,:), kn, &
+        coarse_phalf_d_grid_on_fine(i_coarse,js:je,:), &
+        remapped(i_coarse,js:je,:), js, je, iv, kord, ptop)
+    enddo
+
+    ! 5. Create mask
+    do k = 1, npz
+      where (coarse_phalf_d_grid_on_fine(:,:,k+1) .lt. phalf_d_grid(:,:,npz+1))
+        mask(:,:,k) = .true.
+      elsewhere
+        mask(:,:,k) = .false.
+      endwhere
+    enddo
+
+    ! 6. Coarsen the remapped field
+    call weighted_block_edge_average_y_pre_downsampled(remapped, dy, result, mask, npz)
+  end subroutine remap_edges_along_y
 end module coarse_graining_mod


### PR DESCRIPTION
This is an implementation of our method of coarse-graining dynamical core restart files on surfaces of constant pressure.  A notebook verifying that this works against our offline Python method can be found [here](https://github.com/VulcanClimateModeling/explore/blob/master/spencerc/2020-11-18-verify-pressure-level-coarsening/2020-11-18-verify-pressure-level-coarsening.ipynb).

This builds off of work done in https://github.com/VulcanClimateModeling/fv3gfs-fortran/pull/58, which ported code to coarse-grain cell-center fields on surfaces of constant pressure.  Here we add the slightly more complicated procedure of doing this for the D-grid horizontal winds.  With each of those methods implemented, we can coarse-grain all the dynamical core restart variables on pressure.