### PR TITLE
[VCMML-679] Correct "omega" diagnostic to be mass-conserving in the non-hydrostatic model

### DIFF
--- a/FV3/atmos_cubed_sphere/driver/fvGFS/atmosphere.F90
+++ b/FV3/atmos_cubed_sphere/driver/fvGFS/atmosphere.F90
@@ -716,7 +716,7 @@ contains
                        Atm(n)%gridstruct,  Atm(n)%flagstruct,                    &
                        Atm(n)%neststruct,  Atm(n)%idiag, Atm(n)%bd,              &
                        Atm(n)%parent_grid, Atm(n)%domain,Atm(n)%diss_est,        &
-                       Atm(n)%vulcan_omga)
+                       Atm(n)%lagrangian_tendency_of_hydrostatic_pressure)
     
      !$ser savepoint FVDynamics-Out
      !$ser data  u=Atm(n)%u v=Atm(n)%v w=Atm(n)%w delz=Atm(n)%delz pt=Atm(n)%pt delp=Atm(n)%delp qvapor=Atm(n)%q(:,:,:,sphum) qliquid=Atm(n)%q(:,:,:,liq_wat) qice=Atm(n)%q(:,:,:,ice_wat) qrain=Atm(n)%q(:,:,:,rainwat) qsnow=Atm(n)%q(:,:,:,snowwat) qgraupel=Atm(n)%q(:,:,:,graupel) qcld=Atm(n)%q(:,:,:,cld_amt) qo3mr=Atm(n)%q(:,:,:,o3mr) ps=Atm(n)%ps pe=Atm(n)%pe pk=Atm(n)%pk peln=Atm(n)%peln pkz=Atm(n)%pkz phis=Atm(n)%phis q_con=Atm(n)%q_con omga=Atm(n)%omga ua=Atm(n)%ua va=Atm(n)%va uc=Atm(n)%uc vc=Atm(n)%vc mfxd=Atm(n)%mfx mfyd=Atm(n)%mfy cxd=Atm(n)%cx cyd=Atm(n)%cy diss_estd=Atm(n)%diss_est
@@ -1817,7 +1817,7 @@ contains
                         Atm(mytile)%cx, Atm(mytile)%cy, Atm(mytile)%ze0, Atm(mytile)%flagstruct%hybrid_z,         &
                         Atm(mytile)%gridstruct, Atm(mytile)%flagstruct,                                           &
                         Atm(mytile)%neststruct, Atm(mytile)%idiag, Atm(mytile)%bd, Atm(mytile)%parent_grid,       &
-                        Atm(mytile)%domain,Atm(mytile)%diss_est, Atm(mytile)%vulcan_omga)
+                        Atm(mytile)%domain,Atm(mytile)%diss_est, Atm(mytile)%lagrangian_tendency_of_hydrostatic_pressure)
 ! Backward
        call fv_dynamics(Atm(mytile)%npx, Atm(mytile)%npy, npz,  nq, Atm(mytile)%ng, -dt_atmos, 0.,                &
                         Atm(mytile)%flagstruct%fill, Atm(mytile)%flagstruct%reproduce_sum, kappa, cp_air, zvir,   &
@@ -1832,7 +1832,7 @@ contains
                         Atm(mytile)%cx,    Atm(mytile)%cy,   Atm(mytile)%ze0, Atm(mytile)%flagstruct%hybrid_z,    &
                         Atm(mytile)%gridstruct, Atm(mytile)%flagstruct,                                           &
                         Atm(mytile)%neststruct, Atm(mytile)%idiag, Atm(mytile)%bd, Atm(mytile)%parent_grid,       &
-                        Atm(mytile)%domain,Atm(mytile)%diss_est, Atm(mytile)%vulcan_omga)
+                        Atm(mytile)%domain,Atm(mytile)%diss_est, Atm(mytile)%lagrangian_tendency_of_hydrostatic_pressure)
 !Nudging back to IC
 !$omp parallel do default (none) &
 !$omp              shared (pref, npz, jsc, jec, isc, iec, n, sphum, Atm, u0, v0, t0, dp0, xt, zvir, mytile, nudge_dz, dz0) &
@@ -1909,7 +1909,7 @@ contains
                         Atm(mytile)%cx, Atm(mytile)%cy, Atm(mytile)%ze0, Atm(mytile)%flagstruct%hybrid_z,         &
                         Atm(mytile)%gridstruct, Atm(mytile)%flagstruct,                                           &
                         Atm(mytile)%neststruct, Atm(mytile)%idiag, Atm(mytile)%bd, Atm(mytile)%parent_grid,       &
-                        Atm(mytile)%domain,Atm(mytile)%diss_est, Atm(mytile)%vulcan_omga)
+                        Atm(mytile)%domain,Atm(mytile)%diss_est, Atm(mytile)%lagrangian_tendency_of_hydrostatic_pressure)
 ! Forward call
        call fv_dynamics(Atm(mytile)%npx, Atm(mytile)%npy, npz,  nq, Atm(mytile)%ng, dt_atmos, 0.,                 &
                         Atm(mytile)%flagstruct%fill, Atm(mytile)%flagstruct%reproduce_sum, kappa, cp_air, zvir,   &
@@ -1924,7 +1924,7 @@ contains
                         Atm(mytile)%cx, Atm(mytile)%cy, Atm(mytile)%ze0, Atm(mytile)%flagstruct%hybrid_z,         &
                         Atm(mytile)%gridstruct, Atm(mytile)%flagstruct,                                           &
                         Atm(mytile)%neststruct, Atm(mytile)%idiag, Atm(mytile)%bd, Atm(mytile)%parent_grid,       &
-                        Atm(mytile)%domain,Atm(mytile)%diss_est, Atm(mytile)%vulcan_omga)
+                        Atm(mytile)%domain,Atm(mytile)%diss_est, Atm(mytile)%lagrangian_tendency_of_hydrostatic_pressure)
 ! Nudging back to IC
 !$omp parallel do default (none) &
 !$omp              shared (nudge_dz,npz, jsc, jec, isc, iec, n, sphum, Atm, u0, v0, t0, dz0, dp0, xt, zvir, mytile) &

--- a/FV3/atmos_cubed_sphere/driver/fvGFS/atmosphere.F90
+++ b/FV3/atmos_cubed_sphere/driver/fvGFS/atmosphere.F90
@@ -715,7 +715,8 @@ contains
                        Atm(n)%flagstruct%hybrid_z,                               &
                        Atm(n)%gridstruct,  Atm(n)%flagstruct,                    &
                        Atm(n)%neststruct,  Atm(n)%idiag, Atm(n)%bd,              &
-                       Atm(n)%parent_grid, Atm(n)%domain,Atm(n)%diss_est)
+                       Atm(n)%parent_grid, Atm(n)%domain,Atm(n)%diss_est,        &
+                       Atm(n)%vulcan_omga)
     
      !$ser savepoint FVDynamics-Out
      !$ser data  u=Atm(n)%u v=Atm(n)%v w=Atm(n)%w delz=Atm(n)%delz pt=Atm(n)%pt delp=Atm(n)%delp qvapor=Atm(n)%q(:,:,:,sphum) qliquid=Atm(n)%q(:,:,:,liq_wat) qice=Atm(n)%q(:,:,:,ice_wat) qrain=Atm(n)%q(:,:,:,rainwat) qsnow=Atm(n)%q(:,:,:,snowwat) qgraupel=Atm(n)%q(:,:,:,graupel) qcld=Atm(n)%q(:,:,:,cld_amt) qo3mr=Atm(n)%q(:,:,:,o3mr) ps=Atm(n)%ps pe=Atm(n)%pe pk=Atm(n)%pk peln=Atm(n)%peln pkz=Atm(n)%pkz phis=Atm(n)%phis q_con=Atm(n)%q_con omga=Atm(n)%omga ua=Atm(n)%ua va=Atm(n)%va uc=Atm(n)%uc vc=Atm(n)%vc mfxd=Atm(n)%mfx mfyd=Atm(n)%mfy cxd=Atm(n)%cx cyd=Atm(n)%cy diss_estd=Atm(n)%diss_est
@@ -1816,7 +1817,7 @@ contains
                         Atm(mytile)%cx, Atm(mytile)%cy, Atm(mytile)%ze0, Atm(mytile)%flagstruct%hybrid_z,         &
                         Atm(mytile)%gridstruct, Atm(mytile)%flagstruct,                                           &
                         Atm(mytile)%neststruct, Atm(mytile)%idiag, Atm(mytile)%bd, Atm(mytile)%parent_grid,       &
-                        Atm(mytile)%domain,Atm(mytile)%diss_est)
+                        Atm(mytile)%domain,Atm(mytile)%diss_est, Atm(mytile)%vulcan_omga)
 ! Backward
        call fv_dynamics(Atm(mytile)%npx, Atm(mytile)%npy, npz,  nq, Atm(mytile)%ng, -dt_atmos, 0.,                &
                         Atm(mytile)%flagstruct%fill, Atm(mytile)%flagstruct%reproduce_sum, kappa, cp_air, zvir,   &
@@ -1831,7 +1832,7 @@ contains
                         Atm(mytile)%cx,    Atm(mytile)%cy,   Atm(mytile)%ze0, Atm(mytile)%flagstruct%hybrid_z,    &
                         Atm(mytile)%gridstruct, Atm(mytile)%flagstruct,                                           &
                         Atm(mytile)%neststruct, Atm(mytile)%idiag, Atm(mytile)%bd, Atm(mytile)%parent_grid,       &
-                        Atm(mytile)%domain,Atm(mytile)%diss_est)
+                        Atm(mytile)%domain,Atm(mytile)%diss_est, Atm(mytile)%vulcan_omga)
 !Nudging back to IC
 !$omp parallel do default (none) &
 !$omp              shared (pref, npz, jsc, jec, isc, iec, n, sphum, Atm, u0, v0, t0, dp0, xt, zvir, mytile, nudge_dz, dz0) &
@@ -1908,7 +1909,7 @@ contains
                         Atm(mytile)%cx, Atm(mytile)%cy, Atm(mytile)%ze0, Atm(mytile)%flagstruct%hybrid_z,         &
                         Atm(mytile)%gridstruct, Atm(mytile)%flagstruct,                                           &
                         Atm(mytile)%neststruct, Atm(mytile)%idiag, Atm(mytile)%bd, Atm(mytile)%parent_grid,       &
-                        Atm(mytile)%domain,Atm(mytile)%diss_est)
+                        Atm(mytile)%domain,Atm(mytile)%diss_est, Atm(mytile)%vulcan_omga)
 ! Forward call
        call fv_dynamics(Atm(mytile)%npx, Atm(mytile)%npy, npz,  nq, Atm(mytile)%ng, dt_atmos, 0.,                 &
                         Atm(mytile)%flagstruct%fill, Atm(mytile)%flagstruct%reproduce_sum, kappa, cp_air, zvir,   &
@@ -1923,7 +1924,7 @@ contains
                         Atm(mytile)%cx, Atm(mytile)%cy, Atm(mytile)%ze0, Atm(mytile)%flagstruct%hybrid_z,         &
                         Atm(mytile)%gridstruct, Atm(mytile)%flagstruct,                                           &
                         Atm(mytile)%neststruct, Atm(mytile)%idiag, Atm(mytile)%bd, Atm(mytile)%parent_grid,       &
-                        Atm(mytile)%domain,Atm(mytile)%diss_est)
+                        Atm(mytile)%domain,Atm(mytile)%diss_est, Atm(mytile)%vulcan_omga)
 ! Nudging back to IC
 !$omp parallel do default (none) &
 !$omp              shared (nudge_dz,npz, jsc, jec, isc, iec, n, sphum, Atm, u0, v0, t0, dz0, dp0, xt, zvir, mytile) &

--- a/FV3/atmos_cubed_sphere/model/dyn_core.F90
+++ b/FV3/atmos_cubed_sphere/model/dyn_core.F90
@@ -178,7 +178,7 @@ contains
                      u,  v,  w, delz, pt, q, delp, pe, pk, phis, ws, omga, ptop, pfull, ua, va, & 
                      uc, vc, mfx, mfy, cx, cy, pkz, peln, q_con, ak, bk, &
                      ks, gridstruct, flagstruct, neststruct, idiag, bd, domain, &
-                     init_step, i_pack, end_step, diss_est, vulcan_omga, time_total)
+                     init_step, i_pack, end_step, diss_est, lagrangian_tendency_of_hydrostatic_pressure, time_total)
 
     integer, intent(IN) :: npx
     integer, intent(IN) :: npy
@@ -230,7 +230,7 @@ contains
 !-----------------------------------------------------------------------
     real, intent(out  ):: ws(bd%is:bd%ie,bd%js:bd%je)        !< w at surface
     real, intent(inout):: omga(bd%isd:bd%ied,bd%jsd:bd%jed,npz)    !< Vertical pressure velocity (pa/s)
-    real, allocatable, intent(inout):: vulcan_omga(:,:,:)          !< Alternate vertical pressure velocity (pa/s)
+    real, allocatable, intent(inout):: lagrangian_tendency_of_hydrostatic_pressure(:,:,:)          !< Alternate vertical pressure velocity (pa/s)
     real, intent(inout):: uc(bd%isd:bd%ied+1,bd%jsd:bd%jed  ,npz)  !< (uc, vc) are mostly used as the C grid winds
     real, intent(inout):: vc(bd%isd:bd%ied  ,bd%jsd:bd%jed+1,npz)
     real, intent(inout), dimension(bd%isd:bd%ied,bd%jsd:bd%jed,npz):: ua, va
@@ -787,7 +787,7 @@ contains
      
                                                      call timing_on('d_sw')
 !$OMP parallel do default(none) shared(npz,flagstruct,nord_v,pfull,damp_vt,hydrostatic,last_step, &
-!$OMP                                  is,ie,js,je,isd,ied,jsd,jed,omga,vulcan_omga,delp,gridstruct,npx,npy,  &
+!$OMP                                  is,ie,js,je,isd,ied,jsd,jed,omga,lagrangian_tendency_of_hydrostatic_pressure,delp,gridstruct,npx,npy,  &
 !$OMP                                  ng,zh,vt,ptc,pt,u,v,w,uc,vc,ua,va,divgd,mfx,mfy,cx,cy,     &
 !$OMP                                  crx,cry,xfx,yfx,q_con,zvir,sphum,nq,q,dt,bd,rdt,iep1,jep1, &
 !$OMP                                  heat_source,diss_est,ptop,first_call)                                      &
@@ -885,10 +885,10 @@ contains
                enddo
             enddo
        endif
-       if (last_step .and. allocated(vulcan_omga)) then
+       if (last_step .and. allocated(lagrangian_tendency_of_hydrostatic_pressure)) then
          do j=js,je
             do i=is,ie
-               vulcan_omga(i,j,k) = delp(i,j,k)
+               lagrangian_tendency_of_hydrostatic_pressure(i,j,k) = delp(i,j,k)
             enddo
          enddo
        endif
@@ -930,10 +930,10 @@ contains
                enddo
             enddo
        endif
-       if (last_step .and. allocated(vulcan_omga)) then
+       if (last_step .and. allocated(lagrangian_tendency_of_hydrostatic_pressure)) then
          do j=js,je
               do i=is,ie
-                 vulcan_omga(i,j,k) = vulcan_omga(i,j,k)*(xfx(i,j,k)-xfx(i+1,j,k)+yfx(i,j,k)-yfx(i,j+1,k))*gridstruct%rarea(i,j)*rdt
+                 lagrangian_tendency_of_hydrostatic_pressure(i,j,k) = lagrangian_tendency_of_hydrostatic_pressure(i,j,k)*(xfx(i,j,k)-xfx(i+1,j,k)+yfx(i,j,k)-yfx(i,j+1,k))*gridstruct%rarea(i,j)*rdt
               enddo
            enddo
         endif
@@ -1382,36 +1382,36 @@ contains
           used=send_data(idiag%id_ws, ws, fv_time)
       endif
     endif
-    if (last_step .and. allocated(vulcan_omga)) then
+    if (last_step .and. allocated(lagrangian_tendency_of_hydrostatic_pressure)) then
       if ( flagstruct%use_old_omega ) then
-!$OMP parallel do default(none) shared(is,ie,js,je,npz,vulcan_omga,pe,pem,rdt)
+!$OMP parallel do default(none) shared(is,ie,js,je,npz,lagrangian_tendency_of_hydrostatic_pressure,pe,pem,rdt)
          do k=1,npz
             do j=js,je
                do i=is,ie
-                  vulcan_omga(i,j,k) = (pe(i,k+1,j) - pem(i,k+1,j)) * rdt
+                  lagrangian_tendency_of_hydrostatic_pressure(i,j,k) = (pe(i,k+1,j) - pem(i,k+1,j)) * rdt
                enddo
             enddo
          enddo
 !------------------------------
 ! Compute the "advective term"
 !------------------------------
-         call adv_pe(ua, va, pem, vulcan_omga, gridstruct, bd, npx, npy,  npz, ng)
+         call adv_pe(ua, va, pem, lagrangian_tendency_of_hydrostatic_pressure, gridstruct, bd, npx, npy,  npz, ng)
       else
-!$OMP parallel do default(none) shared(is,ie,js,je,npz,vulcan_omga) private(om2d)
+!$OMP parallel do default(none) shared(is,ie,js,je,npz,lagrangian_tendency_of_hydrostatic_pressure) private(om2d)
          do j=js,je
             do k=1,npz
                do i=is,ie
-                  om2d(i,k) = vulcan_omga(i,j,k)
+                  om2d(i,k) = lagrangian_tendency_of_hydrostatic_pressure(i,j,k)
                enddo
             enddo
             do k=2,npz
                do i=is,ie
-                  om2d(i,k) = om2d(i,k-1) + vulcan_omga(i,j,k)
+                  om2d(i,k) = om2d(i,k-1) + lagrangian_tendency_of_hydrostatic_pressure(i,j,k)
                enddo
             enddo
             do k=2,npz
                do i=is,ie
-                  vulcan_omga(i,j,k) = om2d(i,k)
+                  lagrangian_tendency_of_hydrostatic_pressure(i,j,k) = om2d(i,k)
                enddo
             enddo
          enddo

--- a/FV3/atmos_cubed_sphere/model/dyn_core.F90
+++ b/FV3/atmos_cubed_sphere/model/dyn_core.F90
@@ -230,7 +230,7 @@ contains
 !-----------------------------------------------------------------------
     real, intent(out  ):: ws(bd%is:bd%ie,bd%js:bd%je)        !< w at surface
     real, intent(inout):: omga(bd%isd:bd%ied,bd%jsd:bd%jed,npz)    !< Vertical pressure velocity (pa/s)
-    real, allocatable, intent(inout):: vulcan_omga(:,:,:)    !< Alternate vertical pressure velocity (pa/s)
+    real, allocatable, intent(inout):: vulcan_omga(:,:,:)          !< Alternate vertical pressure velocity (pa/s)
     real, intent(inout):: uc(bd%isd:bd%ied+1,bd%jsd:bd%jed  ,npz)  !< (uc, vc) are mostly used as the C grid winds
     real, intent(inout):: vc(bd%isd:bd%ied  ,bd%jsd:bd%jed+1,npz)
     real, intent(inout), dimension(bd%isd:bd%ied,bd%jsd:bd%jed,npz):: ua, va

--- a/FV3/atmos_cubed_sphere/model/dyn_core.F90
+++ b/FV3/atmos_cubed_sphere/model/dyn_core.F90
@@ -230,7 +230,7 @@ contains
 !-----------------------------------------------------------------------
     real, intent(out  ):: ws(bd%is:bd%ie,bd%js:bd%je)        !< w at surface
     real, intent(inout):: omga(bd%isd:bd%ied,bd%jsd:bd%jed,npz)    !< Vertical pressure velocity (pa/s)
-    real, intent(inout):: vulcan_omga(bd%isd:bd%ied,bd%jsd:bd%jed,npz)    !< Alternate vertical pressure velocity (pa/s)
+    real, allocatable, intent(inout):: vulcan_omga(:,:,:)    !< Alternate vertical pressure velocity (pa/s)
     real, intent(inout):: uc(bd%isd:bd%ied+1,bd%jsd:bd%jed  ,npz)  !< (uc, vc) are mostly used as the C grid winds
     real, intent(inout):: vc(bd%isd:bd%ied  ,bd%jsd:bd%jed+1,npz)
     real, intent(inout), dimension(bd%isd:bd%ied,bd%jsd:bd%jed,npz):: ua, va
@@ -885,7 +885,7 @@ contains
                enddo
             enddo
        endif
-       if (last_step) then
+       if (last_step .and. allocated(vulcan_omga)) then
          do j=js,je
             do i=is,ie
                vulcan_omga(i,j,k) = delp(i,j,k)
@@ -930,7 +930,7 @@ contains
                enddo
             enddo
        endif
-       if (last_step) then
+       if (last_step .and. allocated(vulcan_omga)) then
          do j=js,je
               do i=is,ie
                  vulcan_omga(i,j,k) = vulcan_omga(i,j,k)*(xfx(i,j,k)-xfx(i+1,j,k)+yfx(i,j,k)-yfx(i,j+1,k))*gridstruct%rarea(i,j)*rdt
@@ -1382,7 +1382,7 @@ contains
           used=send_data(idiag%id_ws, ws, fv_time)
       endif
     endif
-    if (last_step ) then
+    if (last_step .and. allocated(vulcan_omga)) then
       if ( flagstruct%use_old_omega ) then
 !$OMP parallel do default(none) shared(is,ie,js,je,npz,vulcan_omga,pe,pem,rdt)
          do k=1,npz

--- a/FV3/atmos_cubed_sphere/model/dyn_core.F90
+++ b/FV3/atmos_cubed_sphere/model/dyn_core.F90
@@ -178,7 +178,7 @@ contains
                      u,  v,  w, delz, pt, q, delp, pe, pk, phis, ws, omga, ptop, pfull, ua, va, & 
                      uc, vc, mfx, mfy, cx, cy, pkz, peln, q_con, ak, bk, &
                      ks, gridstruct, flagstruct, neststruct, idiag, bd, domain, &
-                     init_step, i_pack, end_step, diss_est,time_total)
+                     init_step, i_pack, end_step, diss_est, vulcan_omga, time_total)
 
     integer, intent(IN) :: npx
     integer, intent(IN) :: npy
@@ -230,6 +230,7 @@ contains
 !-----------------------------------------------------------------------
     real, intent(out  ):: ws(bd%is:bd%ie,bd%js:bd%je)        !< w at surface
     real, intent(inout):: omga(bd%isd:bd%ied,bd%jsd:bd%jed,npz)    !< Vertical pressure velocity (pa/s)
+    real, intent(inout):: vulcan_omga(bd%isd:bd%ied,bd%jsd:bd%jed,npz)    !< Alternate vertical pressure velocity (pa/s)
     real, intent(inout):: uc(bd%isd:bd%ied+1,bd%jsd:bd%jed  ,npz)  !< (uc, vc) are mostly used as the C grid winds
     real, intent(inout):: vc(bd%isd:bd%ied  ,bd%jsd:bd%jed+1,npz)
     real, intent(inout), dimension(bd%isd:bd%ied,bd%jsd:bd%jed,npz):: ua, va
@@ -786,7 +787,7 @@ contains
      
                                                      call timing_on('d_sw')
 !$OMP parallel do default(none) shared(npz,flagstruct,nord_v,pfull,damp_vt,hydrostatic,last_step, &
-!$OMP                                  is,ie,js,je,isd,ied,jsd,jed,omga,delp,gridstruct,npx,npy,  &
+!$OMP                                  is,ie,js,je,isd,ied,jsd,jed,omga,vulcan_omga,delp,gridstruct,npx,npy,  &
 !$OMP                                  ng,zh,vt,ptc,pt,u,v,w,uc,vc,ua,va,divgd,mfx,mfy,cx,cy,     &
 !$OMP                                  crx,cry,xfx,yfx,q_con,zvir,sphum,nq,q,dt,bd,rdt,iep1,jep1, &
 !$OMP                                  heat_source,diss_est,ptop,first_call)                                      &
@@ -884,6 +885,13 @@ contains
                enddo
             enddo
        endif
+       if (last_step) then
+         do j=js,je
+            do i=is,ie
+               vulcan_omga(i,j,k) = delp(i,j,k)
+            enddo
+         enddo
+       endif
 
 !--- external mode divergence damping ---
        if ( flagstruct%d_ext > 0. )  &
@@ -922,6 +930,14 @@ contains
                enddo
             enddo
        endif
+       if (last_step) then
+         do j=js,je
+              do i=is,ie
+                 vulcan_omga(i,j,k) = vulcan_omga(i,j,k)*(xfx(i,j,k)-xfx(i+1,j,k)+yfx(i,j,k)-yfx(i,j+1,k))*gridstruct%rarea(i,j)*rdt
+              enddo
+           enddo
+        endif
+
 
        if ( flagstruct%d_ext > 0. ) then
             do j=js,jep1
@@ -1366,6 +1382,41 @@ contains
           used=send_data(idiag%id_ws, ws, fv_time)
       endif
     endif
+    if (last_step ) then
+      if ( flagstruct%use_old_omega ) then
+!$OMP parallel do default(none) shared(is,ie,js,je,npz,vulcan_omga,pe,pem,rdt)
+         do k=1,npz
+            do j=js,je
+               do i=is,ie
+                  vulcan_omga(i,j,k) = (pe(i,k+1,j) - pem(i,k+1,j)) * rdt
+               enddo
+            enddo
+         enddo
+!------------------------------
+! Compute the "advective term"
+!------------------------------
+         call adv_pe(ua, va, pem, vulcan_omga, gridstruct, bd, npx, npy,  npz, ng)
+      else
+!$OMP parallel do default(none) shared(is,ie,js,je,npz,vulcan_omga) private(om2d)
+         do j=js,je
+            do k=1,npz
+               do i=is,ie
+                  om2d(i,k) = vulcan_omga(i,j,k)
+               enddo
+            enddo
+            do k=2,npz
+               do i=is,ie
+                  om2d(i,k) = om2d(i,k-1) + vulcan_omga(i,j,k)
+               enddo
+            enddo
+            do k=2,npz
+               do i=is,ie
+                  vulcan_omga(i,j,k) = om2d(i,k)
+               enddo
+            enddo
+         enddo
+      endif
+   endif
 #endif
 
     if (gridstruct%nested) then

--- a/FV3/atmos_cubed_sphere/model/fv_arrays.F90
+++ b/FV3/atmos_cubed_sphere/model/fv_arrays.F90
@@ -67,6 +67,8 @@ module fv_arrays_mod
            id_dbz, id_maxdbz, id_basedbz, id_dbz4km, id_dbztop, id_dbz_m10C, &
            id_ctz, id_w1km, id_wmaxup, id_wmaxdn, id_cape, id_cin, id_diss
 
+ integer :: id_vulcan_omga
+
 ! Selected p-level fields from 3D variables:
  integer :: id_vort200, id_vort500, id_w500, id_w700
  integer :: id_vort850, id_w850, id_x850, id_srh25, &
@@ -1312,6 +1314,7 @@ module fv_arrays_mod
 !-----------------------------------------------------------------------
     real, _ALLOCATABLE :: phis(:,:)     _NULL  !< Surface geopotential (g*Z_surf)
     real, _ALLOCATABLE :: omga(:,:,:)   _NULL  !< Vertical pressure velocity (pa/s)
+    real, _ALLOCATABLE :: vulcan_omga(:,:,:)  _NULL !< Alternate vertical pressure velocity (pa/s)
     real, _ALLOCATABLE :: ua(:,:,:)     _NULL  !< (ua, va) are mostly used as the A grid winds
     real, _ALLOCATABLE :: va(:,:,:)     _NULL
     real, _ALLOCATABLE :: uc(:,:,:)     _NULL  !< (uc, vc) are mostly used as the C grid winds
@@ -1561,6 +1564,7 @@ contains
     allocate ( Atm%ts(is:ie,js:je) ) ; Atm%ts=real_snan
     allocate ( Atm%phis(isd:ied  ,jsd:jed  ) ) ; Atm%phis=real_snan
     allocate ( Atm%omga(isd:ied  ,jsd:jed  ,npz) ); Atm%omga=0.
+    allocate ( Atm%vulcan_omga(isd:ied  ,jsd:jed  ,npz) ); Atm%vulcan_omga=0.
     allocate (   Atm%ua(isd:ied  ,jsd:jed  ,npz) ) ; Atm%ua=real_snan
     allocate (   Atm%va(isd:ied  ,jsd:jed  ,npz) ) ; Atm%va=real_snan
     allocate (   Atm%uc(isd:ied+1,jsd:jed  ,npz) ) ; Atm%uc=real_snan
@@ -1876,6 +1880,7 @@ contains
     deallocate (  Atm%pkz )
     deallocate ( Atm%phis )
     deallocate ( Atm%omga )
+    deallocate ( Atm%vulcan_omga )
     deallocate (   Atm%ua )
     deallocate (   Atm%va )
     deallocate (   Atm%uc )

--- a/FV3/atmos_cubed_sphere/model/fv_arrays.F90
+++ b/FV3/atmos_cubed_sphere/model/fv_arrays.F90
@@ -67,7 +67,7 @@ module fv_arrays_mod
            id_dbz, id_maxdbz, id_basedbz, id_dbz4km, id_dbztop, id_dbz_m10C, &
            id_ctz, id_w1km, id_wmaxup, id_wmaxdn, id_cape, id_cin, id_diss
 
- integer :: id_vulcan_omga
+ integer :: id_lagrangian_tendency_of_hydrostatic_pressure
 
 ! Selected p-level fields from 3D variables:
  integer :: id_vort200, id_vort500, id_w500, id_w700
@@ -1314,7 +1314,7 @@ module fv_arrays_mod
 !-----------------------------------------------------------------------
     real, _ALLOCATABLE :: phis(:,:)     _NULL  !< Surface geopotential (g*Z_surf)
     real, _ALLOCATABLE :: omga(:,:,:)   _NULL  !< Vertical pressure velocity (pa/s)
-    real, _ALLOCATABLE :: vulcan_omga(:,:,:)  _NULL !< Alternate vertical pressure velocity (pa/s)
+    real, _ALLOCATABLE :: lagrangian_tendency_of_hydrostatic_pressure(:,:,:)  _NULL !< Alternate vertical pressure velocity (pa/s)
     real, _ALLOCATABLE :: ua(:,:,:)     _NULL  !< (ua, va) are mostly used as the A grid winds
     real, _ALLOCATABLE :: va(:,:,:)     _NULL
     real, _ALLOCATABLE :: uc(:,:,:)     _NULL  !< (uc, vc) are mostly used as the C grid winds
@@ -1879,7 +1879,7 @@ contains
     deallocate (  Atm%pkz )
     deallocate ( Atm%phis )
     deallocate ( Atm%omga )
-    if (allocated(Atm%vulcan_omga)) deallocate ( Atm%vulcan_omga )
+    if (allocated(Atm%lagrangian_tendency_of_hydrostatic_pressure)) deallocate ( Atm%lagrangian_tendency_of_hydrostatic_pressure )
     deallocate (   Atm%ua )
     deallocate (   Atm%va )
     deallocate (   Atm%uc )

--- a/FV3/atmos_cubed_sphere/model/fv_arrays.F90
+++ b/FV3/atmos_cubed_sphere/model/fv_arrays.F90
@@ -1564,7 +1564,6 @@ contains
     allocate ( Atm%ts(is:ie,js:je) ) ; Atm%ts=real_snan
     allocate ( Atm%phis(isd:ied  ,jsd:jed  ) ) ; Atm%phis=real_snan
     allocate ( Atm%omga(isd:ied  ,jsd:jed  ,npz) ); Atm%omga=0.
-    allocate ( Atm%vulcan_omga(isd:ied  ,jsd:jed  ,npz) ); Atm%vulcan_omga=0.
     allocate (   Atm%ua(isd:ied  ,jsd:jed  ,npz) ) ; Atm%ua=real_snan
     allocate (   Atm%va(isd:ied  ,jsd:jed  ,npz) ) ; Atm%va=real_snan
     allocate (   Atm%uc(isd:ied+1,jsd:jed  ,npz) ) ; Atm%uc=real_snan
@@ -1880,7 +1879,7 @@ contains
     deallocate (  Atm%pkz )
     deallocate ( Atm%phis )
     deallocate ( Atm%omga )
-    deallocate ( Atm%vulcan_omga )
+    if (allocated(Atm%vulcan_omga)) deallocate ( Atm%vulcan_omga )
     deallocate (   Atm%ua )
     deallocate (   Atm%va )
     deallocate (   Atm%uc )

--- a/FV3/atmos_cubed_sphere/model/fv_dynamics.F90
+++ b/FV3/atmos_cubed_sphere/model/fv_dynamics.F90
@@ -177,7 +177,7 @@ contains
                         ps, pe, pk, peln, pkz, phis, q_con, omga, ua, va, uc, vc,     &
                         ak, bk, mfx, mfy, cx, cy, ze0, hybrid_z,                      &
                         gridstruct, flagstruct, neststruct, idiag, bd,                &
-                        parent_grid, domain, diss_est, vulcan_omga, time_total)
+                        parent_grid, domain, diss_est, lagrangian_tendency_of_hydrostatic_pressure, time_total)
 
 #ifdef CCPP
     use mpp_mod,   only: FATAL, mpp_error
@@ -233,7 +233,7 @@ contains
 !-----------------------------------------------------------------------
     real, intent(inout) :: phis(bd%isd:bd%ied,bd%jsd:bd%jed)       !< Surface geopotential (g*Z_surf)
     real, intent(inout) :: omga(bd%isd:bd%ied,bd%jsd:bd%jed,npz)   !< Vertical pressure velocity (pa/s)
-    real, allocatable, intent(inout) :: vulcan_omga(:,:,:)   !< Alternate vertical pressure velocity (pa/s)
+    real, allocatable, intent(inout) :: lagrangian_tendency_of_hydrostatic_pressure(:,:,:)   !< Alternate vertical pressure velocity (pa/s)
     real, intent(inout) :: uc(bd%isd:bd%ied+1,bd%jsd:bd%jed  ,npz) !< (uc,vc) mostly used as the C grid winds
     real, intent(inout) :: vc(bd%isd:bd%ied  ,bd%jsd:bd%jed+1,npz)
 
@@ -712,7 +712,7 @@ contains
                     u, v, w, delz, pt, q, delp, pe, pk, phis, ws, omga, ptop, pfull, ua, va,           & 
                     uc, vc, mfx, mfy, cx, cy, pkz, peln, q_con, ak, bk, ks, &
                     gridstruct, flagstruct, neststruct, idiag, bd, &
-                    domain, n_map==1, i_pack, last_step, diss_est, vulcan_omga, time_total)
+                    domain, n_map==1, i_pack, last_step, diss_est, lagrangian_tendency_of_hydrostatic_pressure, time_total)
                                          call timing_off('DYN_CORE')
       !$ser savepoint DynCore-Out
       !$ser data cappa=cappa u=u v=v w=w delz=delz pt=pt delp=delp pe=pe pk=pk phis=phis wsd=ws omga=omga ptop=ptop pfull=pfull ua=ua va=va uc=uc vc=vc mfxd=mfx mfyd=mfy cxd=cx cyd=cy pkz=pkz peln=peln q_con=q_con diss_estd=diss_est  
@@ -806,7 +806,7 @@ contains
                      ng, ua, va, omga, dp1, ws, fill, reproduce_sum,                    &
                      idiag%id_mdt>0, dtdt_m, ptop, ak, bk, pfull, gridstruct, domain,   &
                      flagstruct%do_sat_adj, hydrostatic, hybrid_z, do_omega,            &
-                     flagstruct%adiabatic, do_adiabatic_init, vulcan_omga)
+                     flagstruct%adiabatic, do_adiabatic_init, lagrangian_tendency_of_hydrostatic_pressure)
          !$ser savepoint Remapping-Out
          !$ser data te_2d=te_2d pk=pk tracers=q delp=delp pe=pe ps=ps u=u v=v w=w pt=pt delz=delz q_con=q_con cappa=cappa ua=ua va=va omga=omga peln=peln pkz=pkz dp1=dp1
 
@@ -847,8 +847,8 @@ contains
 !--------------------------
             if(flagstruct%nf_omega>0)    &
             call del2_cubed(omga, 0.18*gridstruct%da_min, gridstruct, domain, npx, npy, npz, flagstruct%nf_omega, bd)
-            if (allocated(vulcan_omga)) then
-               call del2_cubed(vulcan_omga, 0.18*gridstruct%da_min, gridstruct, domain, npx, npy, npz, flagstruct%nf_omega, bd)
+            if (allocated(lagrangian_tendency_of_hydrostatic_pressure)) then
+               call del2_cubed(lagrangian_tendency_of_hydrostatic_pressure, 0.18*gridstruct%da_min, gridstruct, domain, npx, npy, npz, flagstruct%nf_omega, bd)
             endif
          endif
       end if

--- a/FV3/atmos_cubed_sphere/model/fv_dynamics.F90
+++ b/FV3/atmos_cubed_sphere/model/fv_dynamics.F90
@@ -233,7 +233,7 @@ contains
 !-----------------------------------------------------------------------
     real, intent(inout) :: phis(bd%isd:bd%ied,bd%jsd:bd%jed)       !< Surface geopotential (g*Z_surf)
     real, intent(inout) :: omga(bd%isd:bd%ied,bd%jsd:bd%jed,npz)   !< Vertical pressure velocity (pa/s)
-    real, intent(inout) :: vulcan_omga(bd%isd:bd%ied,bd%jsd:bd%jed,npz)   !< Alternate vertical pressure velocity (pa/s)
+    real, allocatable, intent(inout) :: vulcan_omga(:,:,:)   !< Alternate vertical pressure velocity (pa/s)
     real, intent(inout) :: uc(bd%isd:bd%ied+1,bd%jsd:bd%jed  ,npz) !< (uc,vc) mostly used as the C grid winds
     real, intent(inout) :: vc(bd%isd:bd%ied  ,bd%jsd:bd%jed+1,npz)
 
@@ -847,7 +847,9 @@ contains
 !--------------------------
             if(flagstruct%nf_omega>0)    &
             call del2_cubed(omga, 0.18*gridstruct%da_min, gridstruct, domain, npx, npy, npz, flagstruct%nf_omega, bd)
-            call del2_cubed(vulcan_omga, 0.18*gridstruct%da_min, gridstruct, domain, npx, npy, npz, flagstruct%nf_omega, bd)
+            if (allocated(vulcan_omga)) then
+               call del2_cubed(vulcan_omga, 0.18*gridstruct%da_min, gridstruct, domain, npx, npy, npz, flagstruct%nf_omega, bd)
+            endif
          endif
       end if
       

--- a/FV3/atmos_cubed_sphere/model/fv_dynamics.F90
+++ b/FV3/atmos_cubed_sphere/model/fv_dynamics.F90
@@ -177,7 +177,7 @@ contains
                         ps, pe, pk, peln, pkz, phis, q_con, omga, ua, va, uc, vc,     &
                         ak, bk, mfx, mfy, cx, cy, ze0, hybrid_z,                      &
                         gridstruct, flagstruct, neststruct, idiag, bd,                &
-                        parent_grid, domain, diss_est, time_total)
+                        parent_grid, domain, diss_est, vulcan_omga, time_total)
 
 #ifdef CCPP
     use mpp_mod,   only: FATAL, mpp_error
@@ -233,6 +233,7 @@ contains
 !-----------------------------------------------------------------------
     real, intent(inout) :: phis(bd%isd:bd%ied,bd%jsd:bd%jed)       !< Surface geopotential (g*Z_surf)
     real, intent(inout) :: omga(bd%isd:bd%ied,bd%jsd:bd%jed,npz)   !< Vertical pressure velocity (pa/s)
+    real, intent(inout) :: vulcan_omga(bd%isd:bd%ied,bd%jsd:bd%jed,npz)   !< Alternate vertical pressure velocity (pa/s)
     real, intent(inout) :: uc(bd%isd:bd%ied+1,bd%jsd:bd%jed  ,npz) !< (uc,vc) mostly used as the C grid winds
     real, intent(inout) :: vc(bd%isd:bd%ied  ,bd%jsd:bd%jed+1,npz)
 
@@ -711,7 +712,7 @@ contains
                     u, v, w, delz, pt, q, delp, pe, pk, phis, ws, omga, ptop, pfull, ua, va,           & 
                     uc, vc, mfx, mfy, cx, cy, pkz, peln, q_con, ak, bk, ks, &
                     gridstruct, flagstruct, neststruct, idiag, bd, &
-                    domain, n_map==1, i_pack, last_step, diss_est,time_total)
+                    domain, n_map==1, i_pack, last_step, diss_est, vulcan_omga, time_total)
                                          call timing_off('DYN_CORE')
       !$ser savepoint DynCore-Out
       !$ser data cappa=cappa u=u v=v w=w delz=delz pt=pt delp=delp pe=pe pk=pk phis=phis wsd=ws omga=omga ptop=ptop pfull=pfull ua=ua va=va uc=uc vc=vc mfxd=mfx mfyd=mfy cxd=cx cyd=cy pkz=pkz peln=peln q_con=q_con diss_estd=diss_est  
@@ -805,7 +806,7 @@ contains
                      ng, ua, va, omga, dp1, ws, fill, reproduce_sum,                    &
                      idiag%id_mdt>0, dtdt_m, ptop, ak, bk, pfull, gridstruct, domain,   &
                      flagstruct%do_sat_adj, hydrostatic, hybrid_z, do_omega,            &
-                     flagstruct%adiabatic, do_adiabatic_init)
+                     flagstruct%adiabatic, do_adiabatic_init, vulcan_omga)
          !$ser savepoint Remapping-Out
          !$ser data te_2d=te_2d pk=pk tracers=q delp=delp pe=pe ps=ps u=u v=v w=w pt=pt delz=delz q_con=q_con cappa=cappa ua=ua va=va omga=omga peln=peln pkz=pkz dp1=dp1
 
@@ -846,6 +847,7 @@ contains
 !--------------------------
             if(flagstruct%nf_omega>0)    &
             call del2_cubed(omga, 0.18*gridstruct%da_min, gridstruct, domain, npx, npy, npz, flagstruct%nf_omega, bd)
+            call del2_cubed(vulcan_omga, 0.18*gridstruct%da_min, gridstruct, domain, npx, npy, npz, flagstruct%nf_omega, bd)
          endif
       end if
       

--- a/FV3/atmos_cubed_sphere/tools/fv_diagnostics.F90
+++ b/FV3/atmos_cubed_sphere/tools/fv_diagnostics.F90
@@ -674,13 +674,13 @@ contains
                'potential temperature perturbation', 'K', missing_value=missing_value )
           idiag%id_theta_e = register_diag_field ( trim(field), 'theta_e', axes(1:3), Time,       &
                'theta_e', 'K', missing_value=missing_value )
-          idiag%id_omga = register_diag_field ( trim(field), 'omega', axes(1:3), Time,      &
-               'omega', 'Pa/s', missing_value=missing_value )
-          idiag%id_vulcan_omga = register_diag_field ( trim(field), 'vulcan_omega', axes(1:3), Time,      &
+          idiag%id_omga = register_diag_field ( trim(field), 'approximate_omega', axes(1:3), Time,      &
+               'approximate_omega', 'Pa/s', missing_value=missing_value )
+          idiag%id_lagrangian_tendency_of_hydrostatic_pressure = register_diag_field ( trim(field), 'omega', axes(1:3), Time,      &
                'Lagrangian tendency of hydrostatic pressure', 'Pa/s', missing_value=missing_value )
-         if (idiag%id_vulcan_omga > 0) then
-            allocate(Atm(n)%vulcan_omga(Atm(n)%bd%isd:Atm(n)%bd%ied,Atm(n)%bd%jsd:Atm(n)%bd%jed,1:npz))
-            Atm(n)%vulcan_omga = 0.0
+         if (idiag%id_lagrangian_tendency_of_hydrostatic_pressure > 0) then
+            allocate(Atm(n)%lagrangian_tendency_of_hydrostatic_pressure(Atm(n)%bd%isd:Atm(n)%bd%ied,Atm(n)%bd%jsd:Atm(n)%bd%jed,1:npz))
+            Atm(n)%lagrangian_tendency_of_hydrostatic_pressure = 0.0
          endif      
           idiag%id_divg  = register_diag_field ( trim(field), 'divg', axes(1:3), Time,      &
                'mean divergence', '1/s', missing_value=missing_value )
@@ -2977,7 +2977,7 @@ contains
 
        if(idiag%id_pt   > 0) used=send_data(idiag%id_pt  , Atm(n)%pt  (isc:iec,jsc:jec,:), Time)
        if(idiag%id_omga > 0) used=send_data(idiag%id_omga, Atm(n)%omga(isc:iec,jsc:jec,:), Time)
-       if(idiag%id_vulcan_omga > 0) used=send_data(idiag%id_vulcan_omga, Atm(n)%vulcan_omga(isc:iec,jsc:jec,:), Time)
+       if(idiag%id_lagrangian_tendency_of_hydrostatic_pressure > 0) used=send_data(idiag%id_lagrangian_tendency_of_hydrostatic_pressure, Atm(n)%lagrangian_tendency_of_hydrostatic_pressure(isc:iec,jsc:jec,:), Time)
        if(idiag%id_diss > 0) used=send_data(idiag%id_diss, Atm(n)%diss_est(isc:iec,jsc:jec,:), Time)
        
        allocate( a3(isc:iec,jsc:jec,npz) )

--- a/FV3/atmos_cubed_sphere/tools/fv_diagnostics.F90
+++ b/FV3/atmos_cubed_sphere/tools/fv_diagnostics.F90
@@ -677,7 +677,7 @@ contains
           idiag%id_omga = register_diag_field ( trim(field), 'omega', axes(1:3), Time,      &
                'omega', 'Pa/s', missing_value=missing_value )
           idiag%id_vulcan_omga = register_diag_field ( trim(field), 'vulcan_omega', axes(1:3), Time,      &
-               'vulcan_omega', 'Pa/s', missing_value=missing_value )
+               'Lagrangian tendency of hydrostatic pressure', 'Pa/s', missing_value=missing_value )
          if (idiag%id_vulcan_omga > 0) then
             allocate(Atm(n)%vulcan_omga(Atm(n)%bd%isd:Atm(n)%bd%ied,Atm(n)%bd%jsd:Atm(n)%bd%jed,1:npz))
             Atm(n)%vulcan_omga = 0.0

--- a/FV3/atmos_cubed_sphere/tools/fv_diagnostics.F90
+++ b/FV3/atmos_cubed_sphere/tools/fv_diagnostics.F90
@@ -678,6 +678,10 @@ contains
                'omega', 'Pa/s', missing_value=missing_value )
           idiag%id_vulcan_omga = register_diag_field ( trim(field), 'vulcan_omega', axes(1:3), Time,      &
                'vulcan_omega', 'Pa/s', missing_value=missing_value )
+         if (idiag%id_vulcan_omga > 0) then
+            allocate(Atm(n)%vulcan_omga(Atm(n)%bd%isd:Atm(n)%bd%ied,Atm(n)%bd%jsd:Atm(n)%bd%jed,1:npz))
+            Atm(n)%vulcan_omga = 0.0
+         endif      
           idiag%id_divg  = register_diag_field ( trim(field), 'divg', axes(1:3), Time,      &
                'mean divergence', '1/s', missing_value=missing_value )
           ! diagnotic output for skeb testing

--- a/FV3/atmos_cubed_sphere/tools/fv_diagnostics.F90
+++ b/FV3/atmos_cubed_sphere/tools/fv_diagnostics.F90
@@ -676,6 +676,8 @@ contains
                'theta_e', 'K', missing_value=missing_value )
           idiag%id_omga = register_diag_field ( trim(field), 'omega', axes(1:3), Time,      &
                'omega', 'Pa/s', missing_value=missing_value )
+          idiag%id_vulcan_omga = register_diag_field ( trim(field), 'vulcan_omega', axes(1:3), Time,      &
+               'vulcan_omega', 'Pa/s', missing_value=missing_value )
           idiag%id_divg  = register_diag_field ( trim(field), 'divg', axes(1:3), Time,      &
                'mean divergence', '1/s', missing_value=missing_value )
           ! diagnotic output for skeb testing
@@ -2971,6 +2973,7 @@ contains
 
        if(idiag%id_pt   > 0) used=send_data(idiag%id_pt  , Atm(n)%pt  (isc:iec,jsc:jec,:), Time)
        if(idiag%id_omga > 0) used=send_data(idiag%id_omga, Atm(n)%omga(isc:iec,jsc:jec,:), Time)
+       if(idiag%id_vulcan_omga > 0) used=send_data(idiag%id_vulcan_omga, Atm(n)%vulcan_omga(isc:iec,jsc:jec,:), Time)
        if(idiag%id_diss > 0) used=send_data(idiag%id_diss, Atm(n)%diss_est(isc:iec,jsc:jec,:), Time)
        
        allocate( a3(isc:iec,jsc:jec,npz) )


### PR DESCRIPTION
This PR adds a new mass-conserving diagnostic for the pressure velocity, which is computed based on the outline [here](https://paper.dropbox.com/doc/Omega-calculation-in-FV3-ToalbcpBZXZq903Rf6aFV#:uid=561711331740789258903736&h2=Notes-on-FV3-code) (the original does not conserve mass in the non-hydrostatic version of the model).  Essentially this computes omega in non-hydrostatic mode the same way it is computed in hydrostatic mode.  We replace the original "omega" diagnostic with this new calculation and rename the old omega diagnostic "approximate_omega."

This diagnostic tends to behave more reasonably in the sense that it averages out more closely to zero in the global mean where the model uses pure pressure vertical levels.  See [this notebook](https://github.com/VulcanClimateModeling/explore/blob/master/spencerc/2020-12-01-test-vulcan-omega/2020-12-01-test-vulcan-omega.ipynb) for a demonstration.

This is currently implemented as a separate field; I've taken care only to allocate memory for / compute it if it is requested as a diagnostic.  An alternative approach would be to add a namelist flag that would dictate how the native omega was computed.  That said, omega is used as an input in the physics so we may not want to impact things there:

https://github.com/VulcanClimateModeling/fv3gfs-fortran/blob/91d68b66a22aec81a6eb567c80d31804d88355a7/FV3/atmos_cubed_sphere/driver/fvGFS/atmosphere.F90#L2062

