### PR TITLE
Changes in order to be able to compile bare-metal on Piz Daint

### DIFF
--- a/FMS/fms/fms.F90
+++ b/FMS/fms/fms.F90
@@ -299,7 +299,7 @@ integer, public :: clock_flag_default
 
 !   ---- private data for check_nml_error ----
 
-   integer, private :: num_nml_error_codes, nml_error_codes(20)
+   !integer, private :: num_nml_error_codes, nml_error_codes(20)
    logical, private :: do_nml_error_init = .true.
    private  nml_error_init
 
@@ -444,7 +444,7 @@ subroutine fms_init (localcomm )
     if (mpp_pe() == mpp_root_pe()) then
       unit = stdlog()
       write (unit, nml=fms_nml)
-      write (unit,*) 'nml_error_codes=', nml_error_codes(1:num_nml_error_codes)
+      !write (unit,*) 'nml_error_codes=', nml_error_codes(1:num_nml_error_codes)
     endif
 
     call memutils_init( print_memory_usage )

--- a/FV3/atmos_cubed_sphere/model/fv_arrays.F90
+++ b/FV3/atmos_cubed_sphere/model/fv_arrays.F90
@@ -49,7 +49,7 @@ module fv_arrays_mod
   real, parameter:: real_big = 1.e30   ! big enough to cause blowup if used
   real, parameter:: real_snan=x'FFF7FFFFFFFFFFFF'
 #endif
-  real, parameter:: i4_in=-huge(1)
+  integer, parameter:: i4_in=-huge(1)
   type fv_diag_type
 
 

--- a/FV3/compile
+++ b/FV3/compile
@@ -21,20 +21,24 @@ set -x
 echo "Running make" "$@"
 
 make clean
-make -j 8 DEBUG=Y "$@" 2>&1 | tee compile_debug.out
-mv fv3.exe fv3_debug.exe
+make -j 8 DEBUG=Y "$@" 2>&1 | tee compile_64bit_debug.out
+mv fv3.exe fv3_64bit_debug.exe
 
 make clean
-make -j 8 "$@" 2>&1 | tee compile_default.out
-mv fv3.exe fv3_default.exe
+make -j 8 "$@" 2>&1 | tee compile_64bit.out
+mv fv3.exe fv3_64bit.exe
 
 make clean
-make -j 8 OPENMP= "$@" 2>&1 | tee compile_noomp.out
-mv fv3.exe fv3_noomp.exe
+make -j 8 OPENMP= "$@" 2>&1 | tee compile_64bit_noomp.out
+mv fv3.exe fv3_64bit_noomp.exe
 
-make clean
-make -j 8 32BIT=Y "$@" 2>&1 | tee compile_32bit.out
-mv fv3.exe fv3_32bit.exe
+#make clean
+#make -j 8 DEBUG=Y 32BIT=Y "$@" 2>&1 | tee compile_32bit_debug.out
+#mv fv3.exe fv3_32bit_debug.exe
+
+#make clean
+#make -j 8 32BIT=Y "$@" 2>&1 | tee compile_32bit.out
+#mv fv3.exe fv3_32bit.exe
 
 echo
 echo "Compilation finished successfully."

--- a/FV3/compile
+++ b/FV3/compile
@@ -1,0 +1,41 @@
+#!/bin/bash
+set -eu
+
+echo
+
+if [[ ! -f conf/configure.fv3 ]]; then
+    echo "File conf/configure.fv3 not found!"
+    echo "Running ./configure .... "
+    ./configure
+fi
+
+if [[ -f conf/modules.fv3 ]]; then
+    echo -n "Loading modules .... "
+    source conf/modules.fv3
+    echo "done."
+    echo
+fi
+
+set -x
+
+echo "Running make" "$@"
+
+make clean
+make -j 8 DEBUG=Y "$@" 2>&1 | tee compile_debug.out
+mv fv3.exe fv3_debug.exe
+
+make clean
+make -j 8 "$@" 2>&1 | tee compile_default.out
+mv fv3.exe fv3_default.exe
+
+make clean
+make -j 8 OPENMP= "$@" 2>&1 | tee compile_noomp.out
+mv fv3.exe fv3_noomp.exe
+
+make clean
+make -j 8 32BIT=Y "$@" 2>&1 | tee compile_32bit.out
+mv fv3.exe fv3_32bit.exe
+
+echo
+echo "Compilation finished successfully."
+echo

--- a/FV3/conf/configure.fv3.daint_gnu
+++ b/FV3/conf/configure.fv3.daint_gnu
@@ -4,6 +4,7 @@
 ############
 FC = ftn 
 CC = cc
+CXX = CC
 LD = $(FC) 
 
 #########
@@ -16,9 +17,25 @@ VERBOSE =
 OPENMP = Y
 AVX2 = Y
 HYDRO = N
+32BIT = N
 
-NEMSIOINC = -I${NCEPLIBS_DIR}/include
-NCEPLIBS = -L${NCEPLIBS_DIR}/lib -lnemsio_d -lbacio_4 -lsp_v2.0.2_d -lw3emc_d -lw3nco_d
+NCEPLIBS_DIR = /project/s1053/install/ncep/gnu
+NEMSIOINC = -I$(NCEPLIBS_DIR)/include
+NCEPLIBS = -L$(NCEPLIBS_DIR)/lib -lbacio_4 -lsp_v2.0.2_d -lw3nco_d
+ifneq ($(OPENMP),)
+  ifeq ($(32BIT),Y)
+    FMS_DIR = /project/s1053/install/fms/gnu_r4
+  else
+    FMS_DIR = /project/s1053/install/fms/gnu_r8
+  endif
+else
+  ifeq ($(32BIT),Y)
+    FMS_DIR = /project/s1053/install/fms/gnu_r4_noomp
+  else
+    FMS_DIR = /project/s1053/install/fms/gnu_r8_noomp
+  endif
+endif
+ESMF_DIR = /project/s1053/install/esmf/8.0.0_gnu
 
 ##############################################
 # Need to use at least GNU Make version 3.81 #
@@ -29,15 +46,15 @@ ifneq ($(need),$(ok))
 $(error Need at least make version $(need).  Load module gmake/3.81)
 endif
 
-INCLUDE = -I$(NETCDF_DIR)/include
+INCLUDE = -I$(NETCDF_DIR)/include -I$(ESMF_DIR)/include -I$(FMS_DIR)/include
 
 FPPFLAGS := -cpp -Wp,-w $(INCLUDE) -fPIC
 CFLAGS := $(INCLUDE) -fPIC
 
 FFLAGS := $(INCLUDE) -fcray-pointer -ffree-line-length-none -fno-range-check -fPIC 
 
-CPPDEFS += -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO -DUSE_GFSL63 -DGFS_PHYS 
-CPPDEFS += -DNEW_TAUCTMAX -DINTERNAL_FILE_NML
+CPPDEFS += -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO -Duse_LARGEFILE -DUSE_GFSL63 -DGFS_PHYS 
+CPPDEFS += -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DNO_INLINE_POST
 
 ifeq ($(GT4PY_DEV),Y)
 CPPDEFS += -DGT4PY_DEV
@@ -106,6 +123,6 @@ FFLAGS += $(FFLAGS_VERBOSE)
 LDFLAGS += $(LDFLAGS_VERBOSE)
 endif
 
-LIBS += -lnetcdff -lnetcdf
+LIBS += -L$(ESMF_DIR)/lib -lesmf -L$(FMS_DIR)/lib -lfms -L$(NETCDF_DIR)/lib -lnetcdff -lnetcdf
 
-LDFLAGS += $(LIBS) -llapack -lblas
+LDFLAGS += $(LIBS) -llapack -lblas -lstdc++ -lc -lrt

--- a/FV3/conf/configure.fv3.daint_intel
+++ b/FV3/conf/configure.fv3.daint_intel
@@ -1,28 +1,41 @@
-## configure.fv3.piz_daint_intel
-##
-## This configure file outlines support for the creation of an Intel compiler build of FV3
-## on the Swiss supercomputer, Piz Daint (a Cray XC-50).  OpenMP and vector (AVX2) support
-## is enabled.  A 64-bit compilation is performed of all the dynamics and physics modules
-##
-##  Mark Cheeseman, Vulcan Inc
-##  July 2, 2020
-##==========================================================================================
-
-# compiler commands 
+############
+# commands #
+############
 FC = ftn
 CC = cc
+CXX = CC
 LD = $(FC) -cxxlib
 
-# fv3 compile options 
+#########
+# flags #
+#########
+# default is 64-bit OpenMP non-hydrostatic build using AVX2
 DEBUG =
 REPRO =
 VERBOSE =
 OPENMP = Y
 AVX2 = Y
 HYDRO = N
+32BIT = N
 
+NCEPLIBS_DIR = /project/s1053/install/ncep/intel
 NEMSIOINC = -I$(NCEPLIBS_DIR)/include
 NCEPLIBS = -L$(NCEPLIBS_DIR)/lib -lbacio_4 -lsp_v2.0.2_d -lw3nco_d
+ifneq ($(OPENMP),)
+  ifeq ($(32BIT),Y)
+    FMS_DIR = /project/s1053/install/fms/intel_r4
+  else
+    FMS_DIR = /project/s1053/install/fms/intel_r8
+  endif
+else
+  ifeq ($(32BIT),Y)
+    FMS_DIR = /project/s1053/install/fms/intel_r4_noomp
+  else
+    FMS_DIR = /project/s1053/install/fms/intel_r8_noomp
+  endif
+endif
+ESMF_DIR = /project/s1053/install/esmf/8.0.0_intel
+MKL_DIR = $(MKLROOT)
 
 ##############################################
 # Need to use at least GNU Make version 3.81 #
@@ -30,11 +43,10 @@ NCEPLIBS = -L$(NCEPLIBS_DIR)/lib -lbacio_4 -lsp_v2.0.2_d -lw3nco_d
 need := 3.81
 ok := $(filter $(need),$(firstword $(sort $(MAKE_VERSION) $(need))))
 ifneq ($(need),$(ok))
-$(error Need at least make version $(need))
+$(error Need at least make version $(need).  Load module gmake/3.81)
 endif
 
-MKL_DIR=${MKLROOT}
-INCLUDE = -I${NETCDF_ROOT}/include -I${ESMF_DIR}/include -I$(MKL_DIR)/include -I$(MKL_DIR)/include/intel64/ilp64 -I${FMS_DIR}/include
+INCLUDE = -I$(NETCDF_DIR)/include -I$(ESMF_DIR)/include -I$(FMS_DIR)/include -I$(MKL_DIR)/include -I$(MKL_DIR)/include/intel64/ilp64
 
 FPPFLAGS := -cpp -Wp,-w $(INCLUDE)
 CFLAGS := $(INCLUDE) -qno-opt-dynamic-align
@@ -114,7 +126,7 @@ FFLAGS += $(FFLAGS_VERBOSE)
 LDFLAGS += $(LDFLAGS_VERBOSE)
 endif
 
-LIBS += -L${ESMF_DIR}/lib -lesmf -L${FMS_DIR}/lib -lFMS -L${NETCDF_ROOT}/lib -lnetcdff -lnetcdf
+LIBS += -L$(ESMF_DIR)/lib -lesmf -L$(FMS_DIR) -lfms -L$(NETCDF_DIR)/lib -lnetcdff -lnetcdf
 
 # Intel MKL library support
 LIBS += -L$(MKL_DIR)/lib/intel64 -Wl,--start-group $(MKL_DIR)/lib/intel64/libmkl_intel_lp64.a $(MKL_DIR)/lib/intel64/libmkl_intel_thread.a $(MKL_DIR)/lib/intel64/libmkl_core.a -Wl,--end-group -liomp5 -lpthread -lm

--- a/FV3/conf/configure.fv3.daint_intel
+++ b/FV3/conf/configure.fv3.daint_intel
@@ -126,7 +126,7 @@ FFLAGS += $(FFLAGS_VERBOSE)
 LDFLAGS += $(LDFLAGS_VERBOSE)
 endif
 
-LIBS += -L$(ESMF_DIR)/lib -lesmf -L$(FMS_DIR) -lfms -L$(NETCDF_DIR)/lib -lnetcdff -lnetcdf
+LIBS += -L$(ESMF_DIR)/lib -lesmf -L$(FMS_DIR)/lib -lfms -L$(NETCDF_DIR)/lib -lnetcdff -lnetcdf
 
 # Intel MKL library support
 LIBS += -L$(MKL_DIR)/lib/intel64 -Wl,--start-group $(MKL_DIR)/lib/intel64/libmkl_intel_lp64.a $(MKL_DIR)/lib/intel64/libmkl_intel_thread.a $(MKL_DIR)/lib/intel64/libmkl_core.a -Wl,--end-group -liomp5 -lpthread -lm

--- a/FV3/conf/modules.fv3.daint_gnu
+++ b/FV3/conf/modules.fv3.daint_gnu
@@ -1,0 +1,12 @@
+##
+## load programming environment
+## this typically includes compiler, MPI and job scheduler
+##
+module load daint-gpu
+module switch PrgEnv-cray PrgEnv-gnu
+module load cray-netcdf
+
+##
+## load nwprod libraries
+##
+

--- a/FV3/conf/modules.fv3.daint_intel
+++ b/FV3/conf/modules.fv3.daint_intel
@@ -2,15 +2,15 @@
 ## purge all currently loaded modules.
 ## do not rely on user's environment
 ##
-module rm PrgEnv-cray PrgEnv-intel PrgEnv-gnu 
 
 ##
 ## load programming environment
 ## this typically includes compiler, MPI and job scheduler
 ##
-module load daint-mc PrgEnv-gnu cray-netcdf
+module load daint-gpu
+module switch PrgEnv-cray PrgEnv-intel
+module load cray-netcdf
 
 ##
 ## load nwprod libraries
 ##
-export NCEPLIBS_DIR=${SCRATCH}/NCEP/gnu

--- a/FV3/configure
+++ b/FV3/configure
@@ -1,0 +1,79 @@
+#!/bin/bash
+set -eu
+
+# copy_diff_files
+copy_diff_files(){
+  if [[ ! -f $2 ]] ; then
+    cp "$1" "$2"
+  else
+  if [[ "$(diff "$1" "$2")" != "" ]] ; then
+    cp "$1" "$2"
+  else
+    echo "confirmed $2"
+  fi
+  fi
+}
+
+CONF_FILES=( conf/configure.fv3.* )
+CONF=()
+
+for f in "${CONF_FILES[@]}"; do
+    name=$(basename "$f")
+    CONF+=( ${name#configure.fv3.} )
+done
+
+usage() {
+    echo
+    echo "Usage: $0 <configuration>"
+    echo
+    echo " where <configuration> is one of:"
+    echo
+    for f in "${CONF[@]}"; do
+        echo "  $f"
+    done
+    echo
+    exit 1
+}
+
+if [[ $# -eq 0 ]]; then
+    CONFIGNAME=""
+    while [[ "$CONFIGNAME" == "" ]]; do
+        echo "Please enter the number of the configuration you want to select:"
+        select CONFIGNAME in "${CONF[@]}"; do
+            if [[ $CONFIGNAME = "" ]]; then
+                 echo
+                 echo "Please enter a valid number. Retry."
+            fi
+            break
+        done
+    done
+    CONFIGURATION=$CONFIGNAME
+elif [[ $# -eq 1 && "$1" == "-h" ]]; then
+    usage
+elif [[ $# -gt 1 ]]; then
+    usage
+elif [[ $# -eq 1 && "$1" == "clean" ]]; then
+    rm -f conf/configure.fv3
+    rm -f conf/modules.fv3
+    exit
+else
+    if [[ "${CONF[@]}" =~ ${1} ]]; then
+        CONFIGURATION=${1}
+    else
+        echo
+        echo "No such configuration. The configuration option \"${1}\" is invalid."
+        usage
+    fi
+fi
+
+CONFIGURE_FILE=conf/configure.fv3.$CONFIGURATION
+MODULES_FILE=conf/modules.fv3.$CONFIGURATION
+
+[[ ! -f "$CONFIGURE_FILE" ]] && usage
+copy_diff_files "$CONFIGURE_FILE" conf/configure.fv3
+
+[[ -f "$MODULES_FILE" ]] && copy_diff_files "$MODULES_FILE" conf/modules.fv3
+
+echo
+echo "The FV3 is now configured on $CONFIGURATION"
+echo


### PR DESCRIPTION
This PR contains several changes to compile the model on Piz Daint using GNU / Intel compiler on bare-metal.
- Adaptions to the configure scripts for daint in `conf/configure.fv3.daint_<compiler>`
- Two bugfixes which were caught by the GNU compiler on Piz Daint (in `fms.F90` and `fv_arrays.F90`)
- Ressurection of the `compile` and `configure` scripts in the FV3 directory