### PR TITLE
Add the rest of the total tracer physics tendency diagnostics

### DIFF
--- a/FV3/atmos_cubed_sphere/driver/fvGFS/atmosphere.F90
+++ b/FV3/atmos_cubed_sphere/driver/fvGFS/atmosphere.F90
@@ -2212,14 +2212,53 @@ contains
    logical, intent(in) :: begin
    type(physics_tendency_diag_type), intent(inout) :: physics_tendency_diag
 
-   integer :: sphum
+   integer :: sphum, liq_wat, ice_wat, rainwat, snowwat, graupel
 
    sphum = get_tracer_index (MODEL_ATMOS, 'sphum')
+   liq_wat = get_tracer_index (MODEL_ATMOS, 'liq_wat')
+   ice_wat = get_tracer_index (MODEL_ATMOS, 'ice_wat')
+   rainwat = get_tracer_index (MODEL_ATMOS, 'rainwat')
+   snowwat = get_tracer_index (MODEL_ATMOS, 'snowwat')
+   graupel = get_tracer_index (MODEL_ATMOS, 'graupel')
 
    if (begin) then
-      if (allocated(physics_tendency_diag%qv_dt)) physics_tendency_diag%qv_dt = q(isc:iec,jsc:jec,1:npz,sphum)
+      if (sphum > 0) then
+        if (allocated(physics_tendency_diag%qv_dt)) physics_tendency_diag%qv_dt = q(isc:iec,jsc:jec,1:npz,sphum)
+      endif
+      if (liq_wat > 0) then
+        if (allocated(physics_tendency_diag%liq_wat_dt)) physics_tendency_diag%liq_wat_dt = q(isc:iec,jsc:jec,1:npz,liq_wat)
+      endif
+      if (ice_wat > 0) then
+        if (allocated(physics_tendency_diag%ice_wat_dt)) physics_tendency_diag%ice_wat_dt = q(isc:iec,jsc:jec,1:npz,ice_wat)
+      endif
+      if (rainwat > 0) then
+        if (allocated(physics_tendency_diag%qr_dt)) physics_tendency_diag%qr_dt = q(isc:iec,jsc:jec,1:npz,rainwat)
+      endif
+      if (snowwat > 0) then
+        if (allocated(physics_tendency_diag%qs_dt)) physics_tendency_diag%qs_dt = q(isc:iec,jsc:jec,1:npz,snowwat)
+      endif
+      if (graupel > 0) then
+        if (allocated(physics_tendency_diag%qg_dt)) physics_tendency_diag%qg_dt = q(isc:iec,jsc:jec,1:npz,graupel)
+      endif
    else
-      if (allocated(physics_tendency_diag%qv_dt)) physics_tendency_diag%qv_dt = (q(isc:iec,jsc:jec,1:npz,sphum) - physics_tendency_diag%qv_dt) / dt
+      if (sphum > 0) then
+        if (allocated(physics_tendency_diag%qv_dt)) physics_tendency_diag%qv_dt = (q(isc:iec,jsc:jec,1:npz,sphum) - physics_tendency_diag%qv_dt) / dt
+      endif
+      if (liq_wat > 0) then
+        if (allocated(physics_tendency_diag%liq_wat_dt)) physics_tendency_diag%liq_wat_dt = (q(isc:iec,jsc:jec,1:npz,liq_wat) - physics_tendency_diag%liq_wat_dt) / dt
+      endif
+      if (ice_wat > 0) then
+        if (allocated(physics_tendency_diag%ice_wat_dt)) physics_tendency_diag%ice_wat_dt = (q(isc:iec,jsc:jec,1:npz,ice_wat) - physics_tendency_diag%ice_wat_dt) / dt
+      endif
+      if (rainwat > 0) then
+        if (allocated(physics_tendency_diag%qr_dt)) physics_tendency_diag%qr_dt = (q(isc:iec,jsc:jec,1:npz,rainwat) - physics_tendency_diag%qr_dt) / dt
+      endif
+      if (snowwat > 0) then
+        if (allocated(physics_tendency_diag%qs_dt)) physics_tendency_diag%qs_dt = (q(isc:iec,jsc:jec,1:npz,snowwat) - physics_tendency_diag%qs_dt) / dt
+      endif
+      if (graupel > 0) then
+        if (allocated(physics_tendency_diag%qg_dt)) physics_tendency_diag%qg_dt = (q(isc:iec,jsc:jec,1:npz,graupel) - physics_tendency_diag%qg_dt) / dt
+      endif
    endif
  end subroutine atmos_phys_qdt_diag
 

--- a/FV3/atmos_cubed_sphere/model/fv_arrays.F90
+++ b/FV3/atmos_cubed_sphere/model/fv_arrays.F90
@@ -115,7 +115,9 @@ module fv_arrays_mod
 
      integer :: id_t_dt_nudge, id_ps_dt_nudge, id_delp_dt_nudge
      integer :: id_u_dt_nudge, id_v_dt_nudge, id_q_dt_nudge
-     integer :: id_t_dt_phys, id_qv_dt_phys, id_column_moistening_nudge
+     integer :: id_t_dt_phys, id_qv_dt_phys, id_liq_wat_dt_phys, id_ice_wat_dt_phys
+     integer :: id_qr_dt_phys, id_qs_dt_phys, id_qg_dt_phys
+     integer :: id_column_moistening_nudge
 
   end type fv_diag_type
 
@@ -1149,6 +1151,11 @@ module fv_arrays_mod
 
       real, allocatable :: t_dt(:,:,:)
       real, allocatable :: qv_dt(:,:,:)
+      real, allocatable :: liq_wat_dt(:,:,:)
+      real, allocatable :: ice_wat_dt(:,:,:)
+      real, allocatable :: qr_dt(:,:,:)
+      real, allocatable :: qs_dt(:,:,:)
+      real, allocatable :: qg_dt(:,:,:)
 
    end type physics_tendency_diag_type
 !>@brief 'allocate_fv_nest_BC_type' is an interface to subroutines

--- a/FV3/atmos_cubed_sphere/tools/coarse_grained_diagnostics.F90
+++ b/FV3/atmos_cubed_sphere/tools/coarse_grained_diagnostics.F90
@@ -167,7 +167,47 @@ contains
     coarse_diagnostics(index)%axes = 3
     coarse_diagnostics(index)%module_name = DYNAMICS
     coarse_diagnostics(index)%name = 'qv_dt_phys_coarse'
-    coarse_diagnostics(index)%description = 'coarse-grained water vapor specific humidity tendency from physics'
+    coarse_diagnostics(index)%description = 'coarse-grained specific humidity tendency from physics'
+    coarse_diagnostics(index)%units = 'kg/kg/s'
+    coarse_diagnostics(index)%reduction_method = MASS_WEIGHTED
+
+    index = index + 1
+    coarse_diagnostics(index)%axes = 3
+    coarse_diagnostics(index)%module_name = DYNAMICS
+    coarse_diagnostics(index)%name = 'liq_wat_dt_phys_coarse'
+    coarse_diagnostics(index)%description = 'coarse-grained liquid water tendency from physics'
+    coarse_diagnostics(index)%units = 'kg/kg/s'
+    coarse_diagnostics(index)%reduction_method = MASS_WEIGHTED
+
+    index = index + 1
+    coarse_diagnostics(index)%axes = 3
+    coarse_diagnostics(index)%module_name = DYNAMICS
+    coarse_diagnostics(index)%name = 'ice_wat_dt_phys_coarse'
+    coarse_diagnostics(index)%description = 'coarse-grained ice water tendency from physics'
+    coarse_diagnostics(index)%units = 'kg/kg/s'
+    coarse_diagnostics(index)%reduction_method = MASS_WEIGHTED
+
+    index = index + 1
+    coarse_diagnostics(index)%axes = 3
+    coarse_diagnostics(index)%module_name = DYNAMICS
+    coarse_diagnostics(index)%name = 'qr_dt_phys_coarse'
+    coarse_diagnostics(index)%description = 'coarse-grained rain water tendency from physics'
+    coarse_diagnostics(index)%units = 'kg/kg/s'
+    coarse_diagnostics(index)%reduction_method = MASS_WEIGHTED
+
+    index = index + 1
+    coarse_diagnostics(index)%axes = 3
+    coarse_diagnostics(index)%module_name = DYNAMICS
+    coarse_diagnostics(index)%name = 'qs_dt_phys_coarse'
+    coarse_diagnostics(index)%description = 'coarse-grained snow water tendency from physics'
+    coarse_diagnostics(index)%units = 'kg/kg/s'
+    coarse_diagnostics(index)%reduction_method = MASS_WEIGHTED
+
+    index = index + 1
+    coarse_diagnostics(index)%axes = 3
+    coarse_diagnostics(index)%module_name = DYNAMICS
+    coarse_diagnostics(index)%name = 'qg_dt_phys_coarse'
+    coarse_diagnostics(index)%description = 'coarse-grained graupel tendency from physics'
     coarse_diagnostics(index)%units = 'kg/kg/s'
     coarse_diagnostics(index)%reduction_method = MASS_WEIGHTED
 
@@ -241,7 +281,52 @@ contains
     coarse_diagnostics(index)%axes = 2
     coarse_diagnostics(index)%module_name = DYNAMICS
     coarse_diagnostics(index)%name = 'int_qv_dt_phys_coarse'
-    coarse_diagnostics(index)%description = 'coarse-grained vertically integrated water vapor specific humidity tendency from physics'
+    coarse_diagnostics(index)%description = 'coarse-grained vertically integrated specific humidity tendency from physics'
+    coarse_diagnostics(index)%units = 'kg/m**2/s'
+    coarse_diagnostics(index)%vertically_integrated = .true.
+    coarse_diagnostics(index)%reduction_method = AREA_WEIGHTED
+
+    index = index + 1
+    coarse_diagnostics(index)%axes = 2
+    coarse_diagnostics(index)%module_name = DYNAMICS
+    coarse_diagnostics(index)%name = 'int_liq_wat_dt_phys_coarse'
+    coarse_diagnostics(index)%description = 'coarse-grained vertically integrated liquid water tendency from physics'
+    coarse_diagnostics(index)%units = 'kg/m**2/s'
+    coarse_diagnostics(index)%vertically_integrated = .true.
+    coarse_diagnostics(index)%reduction_method = AREA_WEIGHTED
+
+    index = index + 1
+    coarse_diagnostics(index)%axes = 2
+    coarse_diagnostics(index)%module_name = DYNAMICS
+    coarse_diagnostics(index)%name = 'int_ice_wat_dt_phys_coarse'
+    coarse_diagnostics(index)%description = 'coarse-grained vertically integrated ice water tendency from physics'
+    coarse_diagnostics(index)%units = 'kg/m**2/s'
+    coarse_diagnostics(index)%vertically_integrated = .true.
+    coarse_diagnostics(index)%reduction_method = AREA_WEIGHTED
+
+    index = index + 1
+    coarse_diagnostics(index)%axes = 2
+    coarse_diagnostics(index)%module_name = DYNAMICS
+    coarse_diagnostics(index)%name = 'int_qr_dt_phys_coarse'
+    coarse_diagnostics(index)%description = 'coarse-grained vertically integrated rain water tendency from physics'
+    coarse_diagnostics(index)%units = 'kg/m**2/s'
+    coarse_diagnostics(index)%vertically_integrated = .true.
+    coarse_diagnostics(index)%reduction_method = AREA_WEIGHTED
+
+    index = index + 1
+    coarse_diagnostics(index)%axes = 2
+    coarse_diagnostics(index)%module_name = DYNAMICS
+    coarse_diagnostics(index)%name = 'int_qs_dt_phys_coarse'
+    coarse_diagnostics(index)%description = 'coarse-grained vertically integrated snow water tendency from physics'
+    coarse_diagnostics(index)%units = 'kg/m**2/s'
+    coarse_diagnostics(index)%vertically_integrated = .true.
+    coarse_diagnostics(index)%reduction_method = AREA_WEIGHTED
+
+    index = index + 1
+    coarse_diagnostics(index)%axes = 2
+    coarse_diagnostics(index)%module_name = DYNAMICS
+    coarse_diagnostics(index)%name = 'int_qg_dt_phys_coarse'
+    coarse_diagnostics(index)%description = 'coarse-grained vertically integrated graupel tendency from physics'
     coarse_diagnostics(index)%units = 'kg/m**2/s'
     coarse_diagnostics(index)%vertically_integrated = .true.
     coarse_diagnostics(index)%reduction_method = AREA_WEIGHTED
@@ -456,6 +541,31 @@ contains
              allocate(Atm(tile_count)%physics_tendency_diag%qv_dt(is:ie,js:je,1:npz))
           endif
           coarse_diagnostic%data%var3 => Atm(tile_count)%physics_tendency_diag%qv_dt(is:ie,js:je,1:npz)
+       elseif (ends_with(coarse_diagnostic%name, 'liq_wat_dt_phys_coarse')) then
+          if (.not. allocated(Atm(tile_count)%physics_tendency_diag%liq_wat_dt)) then
+             allocate(Atm(tile_count)%physics_tendency_diag%liq_wat_dt(is:ie,js:je,1:npz))
+          endif
+          coarse_diagnostic%data%var3 => Atm(tile_count)%physics_tendency_diag%liq_wat_dt(is:ie,js:je,1:npz)
+       elseif (ends_with(coarse_diagnostic%name, 'ice_wat_dt_phys_coarse')) then
+          if (.not. allocated(Atm(tile_count)%physics_tendency_diag%ice_wat_dt)) then
+             allocate(Atm(tile_count)%physics_tendency_diag%ice_wat_dt(is:ie,js:je,1:npz))
+          endif
+          coarse_diagnostic%data%var3 => Atm(tile_count)%physics_tendency_diag%ice_wat_dt(is:ie,js:je,1:npz)
+       elseif (ends_with(coarse_diagnostic%name, 'qr_dt_phys_coarse')) then
+          if (.not. allocated(Atm(tile_count)%physics_tendency_diag%qr_dt)) then
+             allocate(Atm(tile_count)%physics_tendency_diag%qr_dt(is:ie,js:je,1:npz))
+          endif
+          coarse_diagnostic%data%var3 => Atm(tile_count)%physics_tendency_diag%qr_dt(is:ie,js:je,1:npz)
+       elseif (ends_with(coarse_diagnostic%name, 'qs_dt_phys_coarse')) then
+          if (.not. allocated(Atm(tile_count)%physics_tendency_diag%qs_dt)) then
+             allocate(Atm(tile_count)%physics_tendency_diag%qs_dt(is:ie,js:je,1:npz))
+          endif
+          coarse_diagnostic%data%var3 => Atm(tile_count)%physics_tendency_diag%qs_dt(is:ie,js:je,1:npz)
+       elseif (ends_with(coarse_diagnostic%name, 'qg_dt_phys_coarse')) then
+          if (.not. allocated(Atm(tile_count)%physics_tendency_diag%qg_dt)) then
+             allocate(Atm(tile_count)%physics_tendency_diag%qg_dt(is:ie,js:je,1:npz))
+          endif
+          coarse_diagnostic%data%var3 => Atm(tile_count)%physics_tendency_diag%qg_dt(is:ie,js:je,1:npz)
        elseif (ends_with(coarse_diagnostic%name, 't_dt_phys_coarse')) then
           if (.not. allocated(Atm(tile_count)%physics_tendency_diag%t_dt)) then
              allocate(Atm(tile_count)%physics_tendency_diag%t_dt(is:ie,js:je,1:npz))

--- a/FV3/atmos_cubed_sphere/tools/fv_diagnostics.F90
+++ b/FV3/atmos_cubed_sphere/tools/fv_diagnostics.F90
@@ -1109,6 +1109,51 @@ contains
          allocate(Atm(n)%physics_tendency_diag%qv_dt(isc:iec,jsc:jec,npz))
          Atm(n)%physics_tendency_diag%qv_dt = 0.0
     endif
+
+    idiag%id_liq_wat_dt_phys = register_diag_field('dynamics', &
+          'liq_wat_dt_phys', axes(1:3), Time, &
+          'liquid water tendency from physics', 'kg/kg/s', &
+          missing_value=missing_value)
+    if (idiag%id_liq_wat_dt_phys > 0) then
+         allocate(Atm(n)%physics_tendency_diag%liq_wat_dt(isc:iec,jsc:jec,npz))
+         Atm(n)%physics_tendency_diag%liq_wat_dt = 0.0
+    endif
+
+    idiag%id_ice_wat_dt_phys = register_diag_field('dynamics', &
+          'ice_wat_dt_phys', axes(1:3), Time, &
+          'ice water tendency from physics', 'kg/kg/s', &
+          missing_value=missing_value)
+    if (idiag%id_ice_wat_dt_phys > 0) then
+         allocate(Atm(n)%physics_tendency_diag%ice_wat_dt(isc:iec,jsc:jec,npz))
+         Atm(n)%physics_tendency_diag%ice_wat_dt = 0.0
+    endif   
+
+    idiag%id_qr_dt_phys = register_diag_field('dynamics', &
+          'qr_dt_phys', axes(1:3), Time, &
+          'rain water tendency from physics', 'kg/kg/s', &
+          missing_value=missing_value)
+    if (idiag%id_qr_dt_phys > 0) then
+         allocate(Atm(n)%physics_tendency_diag%qr_dt(isc:iec,jsc:jec,npz))
+         Atm(n)%physics_tendency_diag%qr_dt = 0.0
+    endif
+
+    idiag%id_qs_dt_phys = register_diag_field('dynamics', &
+          'qs_dt_phys', axes(1:3), Time, &
+          'snow water tendency from physics', 'kg/kg/s', &
+          missing_value=missing_value)
+    if (idiag%id_qs_dt_phys > 0) then
+         allocate(Atm(n)%physics_tendency_diag%qs_dt(isc:iec,jsc:jec,npz))
+         Atm(n)%physics_tendency_diag%qs_dt = 0.0
+    endif
+
+    idiag%id_qg_dt_phys = register_diag_field('dynamics', &
+          'qg_dt_phys', axes(1:3), Time, &
+          'graupel tendency from physics', 'kg/kg/s', &
+          missing_value=missing_value)
+    if (idiag%id_qg_dt_phys > 0) then
+         allocate(Atm(n)%physics_tendency_diag%qg_dt(isc:iec,jsc:jec,npz))
+         Atm(n)%physics_tendency_diag%qg_dt = 0.0
+    endif
  end subroutine fv_diag_init
 
 
@@ -3143,6 +3188,22 @@ contains
      if (idiag%id_qv_dt_phys > 0) then
         used = send_data(idiag%id_qv_dt_phys, Atm(n)%physics_tendency_diag%qv_dt(isc:iec,jsc:jec,1:npz), Time)
      endif
+     if (idiag%id_liq_wat_dt_phys > 0) then
+        used = send_data(idiag%id_liq_wat_dt_phys, Atm(n)%physics_tendency_diag%liq_wat_dt(isc:iec,jsc:jec,1:npz), Time)
+     endif
+     if (idiag%id_ice_wat_dt_phys > 0) then
+        used = send_data(idiag%id_ice_wat_dt_phys, Atm(n)%physics_tendency_diag%ice_wat_dt(isc:iec,jsc:jec,1:npz), Time)
+     endif
+     if (idiag%id_qr_dt_phys > 0) then
+        used = send_data(idiag%id_qr_dt_phys, Atm(n)%physics_tendency_diag%qr_dt(isc:iec,jsc:jec,1:npz), Time)
+     endif
+     if (idiag%id_qs_dt_phys > 0) then
+        used = send_data(idiag%id_qs_dt_phys, Atm(n)%physics_tendency_diag%qs_dt(isc:iec,jsc:jec,1:npz), Time)
+     endif
+     if (idiag%id_qg_dt_phys > 0) then
+        used = send_data(idiag%id_qg_dt_phys, Atm(n)%physics_tendency_diag%qg_dt(isc:iec,jsc:jec,1:npz), Time)
+     endif
+
    ! enddo  ! end ntileMe do-loop
 
     deallocate ( a2 )


### PR DESCRIPTION
This PR adds full and coarse resolution total tracer physics tendency diagnostics, i.e. for:

- `liq_wat` (`liq_wat_dt_phys`)
- `ice_wat` (`ice_wat_dt_phys`)
- `rainwat` (`qr_dt_phys`)
- `snowwat` (`qs_dt_phys`)
- `graupel` (`qg_dt_phys`)

[This notebook](https://github.com/VulcanClimateModeling/explore/blob/master/spencerc/2020-12-17-phys-dt/2020-12-17-phys-tend-diagnostics.ipynb) verifies that these diagnostics work, both in fine and coarse form, and in vertically integrated form.