### PR TITLE
Bug fix in coarse_graining.F90

### DIFF
--- a/FV3/atmos_model.F90
+++ b/FV3/atmos_model.F90
@@ -82,6 +82,7 @@ use atmosphere_mod,     only: Atm, mytile
 use atmosphere_mod,     only: atmosphere_coarse_graining_parameters
 use atmosphere_mod,     only: atmosphere_coarse_diag_axes
 use atmosphere_mod,     only: atmosphere_coarsening_strategy
+use atmosphere_mod,     only: atmosphere_control_data
 use block_control_mod,  only: block_control_type, define_blocks_packed
 use DYCORE_typedefs,    only: DYCORE_data_type, DYCORE_diag_type
 #ifdef CCPP
@@ -872,7 +873,7 @@ subroutine update_atmos_model_state (Atmos)
   integer :: isec, seconds, isec_fhzero
   integer :: rc
   real(kind=IPD_kind_phys) :: time_int, time_intfull
-  integer :: is, ie, js, je
+  integer :: is, ie, js, je, nk
 !
     call set_atmosphere_pelist()
     call mpp_clock_begin(fv3Clock)
@@ -913,7 +914,7 @@ subroutine update_atmos_model_state (Atmos)
       endif
       if (mpp_pe() == mpp_root_pe()) write(6,*) ' gfs diags time since last bucket empty: ',time_int/3600.,'hrs'
       call atmosphere_nggps_diag(Atmos%Time)
-      call get_fine_array_bounds(is, ie, js, je)
+      call atmosphere_control_data(is, ie, js, je, nk)
       call FV3GFS_diag_output(Atmos%Time, IPD_DIag, Atm_block, IPD_Data, IPD_Control%nx, IPD_Control%ny, &
                             IPD_Control%levs, 1, 1, 1.d0, time_int, time_intfull,              &
                             IPD_Control%fhswr, IPD_Control%fhlwr, &

--- a/FV3/coarse_graining/coarse_graining.F90
+++ b/FV3/coarse_graining/coarse_graining.F90
@@ -75,7 +75,7 @@ module coarse_graining_mod
   end interface weighted_block_edge_average_y_pre_downsampled
 
   ! Global variables for the module, initialized in coarse_graining_init
-  integer :: is = 1, ie = 1, js = 1, je = 1, npz
+  integer :: is, ie, js, je, npz
   integer :: is_coarse, ie_coarse, js_coarse, je_coarse
   character(len=11) :: MODEL_LEVEL = 'model_level'
   character(len=14) :: PRESSURE_LEVEL = 'pressure_level'

--- a/FV3/coarse_graining/coarse_graining.F90
+++ b/FV3/coarse_graining/coarse_graining.F90
@@ -75,7 +75,7 @@ module coarse_graining_mod
   end interface weighted_block_edge_average_y_pre_downsampled
 
   ! Global variables for the module, initialized in coarse_graining_init
-  integer :: is, ie, js, je, npz
+  integer :: is = 1, ie = 1, js = 1, je = 1, npz
   integer :: is_coarse, ie_coarse, js_coarse, je_coarse
   character(len=11) :: MODEL_LEVEL = 'model_level'
   character(len=14) :: PRESSURE_LEVEL = 'pressure_level'


### PR DESCRIPTION
Fixes a bug in `atmos_model.F90` when diagnostics are called (`FV3GFS_diag_output()` on L918) but coarse-graining is not initialized and thus the dimensions (`is, ie, js, je`) of the argument `Atm(mytile)%delp(is:ie, js:je, :)` being passed in are not initialized.

The fix is to replace the call to get the dimensions to the `coarse_graining.F90` module with a call to `atmosphere_control_data` from `atmosphere.F90` which essentially does the same thing.