### PR TITLE
Small bugfix in coverage.sh script to work again

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,3 +4,4 @@ tests/pytest/output/**
 *.so
 fv3.exe
 *.tmp.f90
+coverage_*

--- a/coverage.sh
+++ b/coverage.sh
@@ -46,12 +46,16 @@ mkdir -p ${coverage_dir}
 docker run -it --rm --network host -v ${coverage_dir}:/coverage -v `pwd`/rundir:/rundir ${gcr_url}:gcov bash -c "set -ex; cd /rundir; ./submit_job.sh; pip3 install gcovr; cd /coverage; mkdir physics; cd physics; gcovr -d -r /FV3/gfsphysics --html --html-details -o index.html; cd ../; mkdir dycore; cd dycore; gcovr -d -r /FV3/atmos_cubed_sphere --html --html-details -o index.html"
 
 # cleanup run directory
-if grep Termination ${rundir}/stdout.out ; then
+set +e
+grep Termination ${rundir}/stdout.out > /dev/null
+if [ $? -ne 0 ] ; then
   echo "Warning: Run does not seem to have been successfull. Check the rundir!"
 else
   \rm -rf "${rundir}"
 fi
+set -e
 
 # tell user we're done
 echo "Open coverage_${config_name}/*/index.html to view coverage data"
 exit 0
+


### PR DESCRIPTION
- Introduce small bugfix in `coverage.sh`. Not sure how this ever worked before...
- Add `coverage_*` directories to `.dockerignore` in order to avoid rebuilds

Error on Mac OS was the following (so `Termination` is found by grep in stdout, but run still marked as unsuccessful):
```
+ gcovr -d -r /FV3/atmos_cubed_sphere --html --html-details -o index.html
[0] Termination                           0.620017      0.626813      0.622315      0.003178  0.010     0     0     5
Warning: Run does not seem to have been successfull. Check the rundir!
```