### PR TITLE
Cleanup and extend timers [DSL-313]

### DIFF
--- a/FMS/mpp/include/mpp_comm_mpi.inc
+++ b/FMS/mpp/include/mpp_comm_mpi.inc
@@ -242,7 +242,7 @@ subroutine mpp_exit()
         write( out_unit,'(/a,i6,a)' ) 'Tabulating mpp_clock statistics across ', npes, ' PEs...'
         if( ANY(clocks(1:clock_num)%detailed) ) &
              write( out_unit,'(a)' )'   ... see mpp_clock.out.#### for details on individual PEs.'
-        write( out_unit,'(/32x,a)' ) '          tmin          tmax          tavg          tstd  tfrac grain pemin pemax'
+        write( out_unit,'(/32x,a)' ) '      hits          tmin          tmax          tavg          tstd  tfrac grain pemin pemax'
      end if
      write( log_unit,'(/37x,a)' ) 'time'
 
@@ -259,8 +259,8 @@ subroutine mpp_exit()
         tmax = t; call mpp_max(tmax)
         tavg = t; call mpp_sum(tavg); tavg = tavg/mpp_npes()
         tstd = (t-tavg)**2; call mpp_sum(tstd); tstd = sqrt( tstd/mpp_npes() )
-        if( pe.EQ.root_pe )write( out_unit,'(a32,4f14.6,f7.3,3i6)' ) &
-             clocks(i)%name, tmin, tmax, tavg, tstd, tavg/t_total, &
+        if( pe.EQ.root_pe )write( out_unit,'(a32,i10,4f14.6,f7.3,3i6)' ) &
+             clocks(i)%name, clocks(i)%hits, tmin, tmax, tavg, tstd, tavg/t_total, &
              clocks(i)%grain, minval(peset(clocks(i)%peset_num)%list), &
              maxval(peset(clocks(i)%peset_num)%list)
         write(log_unit,'(a32,f14.6)') clocks(i)%name, clocks(i)%total_ticks*tick_rate

--- a/FMS/mpp/include/mpp_comm_nocomm.inc
+++ b/FMS/mpp/include/mpp_comm_nocomm.inc
@@ -189,7 +189,7 @@ subroutine mpp_exit()
         write( out_unit,'(/a,i6,a)' ) 'Tabulating mpp_clock statistics across ', npes, ' PEs...'
         if( ANY(clocks(1:clock_num)%detailed) ) &
              write( out_unit,'(a)' )'   ... see mpp_clock.out.#### for details on individual PEs.'
-        write( out_unit,'(/32x,a)' ) '          tmin          tmax          tavg          tstd  tfrac grain pemin pemax'
+        write( out_unit,'(/32x,a)' ) '      hits          tmin          tmax          tavg          tstd  tfrac grain pemin pemax'
      else
         write( out_unit,'(/37x,a)' ) 'time'
      end if
@@ -204,8 +204,8 @@ subroutine mpp_exit()
         tmax = t; call mpp_max(tmax)
         tavg = t; call mpp_sum(tavg); tavg = tavg/mpp_npes()
         tstd = (t-tavg)**2; call mpp_sum(tstd); tstd = sqrt( tstd/mpp_npes() )
-        if( pe.EQ.root_pe )write( out_unit,'(a32,4f14.6,f7.3,3i6)' ) &
-             clocks(i)%name, tmin, tmax, tavg, tstd, tavg/t_total, &
+        if( pe.EQ.root_pe )write( out_unit,'(a32,i10,4f14.6,f7.3,3i6)' ) &
+             clocks(i)%name, clocks(i)%hits, tmin, tmax, tavg, tstd, tavg/t_total, &
              clocks(i)%grain, minval(peset(clocks(i)%peset_num)%list), &
              maxval(peset(clocks(i)%peset_num)%list)
         if (pe.NE.root_pe) write(out_unit,'(a32,f14.6)') clocks(i)%name, clocks(i)%total_ticks*tick_rate

--- a/FMS/mpp/include/mpp_comm_sma.inc
+++ b/FMS/mpp/include/mpp_comm_sma.inc
@@ -224,7 +224,7 @@ subroutine mpp_exit()
         write( outunit,'(/a,i6,a)' ) 'Tabulating mpp_clock statistics across ', npes, ' PEs...'
         if( ANY(clocks(1:clock_num)%detailed) ) &
              write( outunit,'(a)' )'   ... see mpp_clock.out.#### for details on individual PEs.'
-        write( outunit,'(/32x,a)' ) '          tmin          tmax          tavg          tstd  tfrac grain pemin pemax'
+        write( outunit,'(/32x,a)' ) '      hits          tmin          tmax          tavg          tstd  tfrac grain pemin pemax'
      end if
      write( logunit, '(/37x,a)' ) 'time'
      call FLUSH( outunit )
@@ -238,8 +238,8 @@ subroutine mpp_exit()
         tmax = t; call mpp_max(tmax)
         tavg = t; call mpp_sum(tavg); tavg = tavg/mpp_npes()
         tstd = (t-tavg)**2; call mpp_sum(tstd); tstd = sqrt( tstd/mpp_npes() )
-        if( pe.EQ.root_pe )write( outunit,'(a32,4f14.6,f7.3,3i6)' ) &
-             clocks(i)%name, tmin, tmax, tavg, tstd, tavg/t_total, &
+        if( pe.EQ.root_pe )write( outunit,'(a32,i10,4f14.6,f7.3,3i6)' ) &
+             clocks(i)%name, clocks(i)%hits, tmin, tmax, tavg, tstd, tavg/t_total, &
              clocks(i)%grain, minval(peset(clocks(i)%peset_num)%list), &
              maxval(peset(clocks(i)%peset_num)%list)
          write(logunit,'(a32,f14.6)') clocks(i)%name, clocks(i)%total_ticks*tick_rate

--- a/FMS/mpp/include/mpp_util.inc
+++ b/FMS/mpp/include/mpp_util.inc
@@ -752,6 +752,7 @@ end function rarray_to_char
     integer                       :: i
 
     clocks(id)%name = name
+    clocks(id)%hits = 0
     clocks(id)%tick = 0
     clocks(id)%total_ticks = 0
     clocks(id)%sync_on_begin = .FALSE.
@@ -864,6 +865,7 @@ end function rarray_to_char
       current_clock = id
     endif
     call SYSTEM_CLOCK( clocks(id)%tick )
+    clocks(id)%hits = clocks(id)%hits + 1
     clocks(id)%is_on = .true.
 !$OMP END MASTER
     return

--- a/FMS/mpp/mpp.F90
+++ b/FMS/mpp/mpp.F90
@@ -277,6 +277,7 @@ private
   type :: clock
      private
      character(len=32)    :: name
+     integer(LONG_KIND)   :: hits
      integer(LONG_KIND)   :: tick
      integer(LONG_KIND)   :: total_ticks
      integer              :: peset_num

--- a/FV3/atmos_cubed_sphere/driver/fvGFS/atmosphere.F90
+++ b/FV3/atmos_cubed_sphere/driver/fvGFS/atmosphere.F90
@@ -245,7 +245,8 @@ character(len=20)   :: mod_name = 'fvGFS/atmosphere_mod'
   integer :: isd, ied, jsd, jed
   integer :: nq                       !  number of transported tracers
   integer :: sec, seconds, days
-  integer :: id_dynam, id_fv_diag, id_subgridz
+  integer :: id_dynam = -1, id_subgridz = -1, id_dynam_other = -1
+  integer :: id_update = -1, id_fv_diag = -1, id_update_other = -1
   logical :: cold_start = .false.     !  used in initial condition
 
   integer, dimension(:), allocatable :: id_tracerdt_dyn
@@ -476,9 +477,13 @@ contains
     call get_eta_level ( npz, ps2, pref(1,2), dum1d, Atm(mytile)%ak, Atm(mytile)%bk )
 
 !  --- initialize clocks for dynamics, physics_down and physics_up
-   id_dynam     = mpp_clock_id ('FV dy-core',  flags = clock_flag_default, grain=CLOCK_SUBCOMPONENT )
-   id_subgridz  = mpp_clock_id ('FV subgrid_z',flags = clock_flag_default, grain=CLOCK_SUBCOMPONENT )
-   id_fv_diag   = mpp_clock_id ('FV Diag',     flags = clock_flag_default, grain=CLOCK_SUBCOMPONENT )
+   id_dynam        = mpp_clock_id ('  3.1.1-fv_dyncore', flags = clock_flag_default, grain=CLOCK_SUBCOMPONENT )
+   id_subgridz     = mpp_clock_id ('  3.1.2-subgrid_z',  flags = clock_flag_default, grain=CLOCK_SUBCOMPONENT )
+   id_dynam_other  = mpp_clock_id ('  3.1.3-other',      flags = clock_flag_default, grain=CLOCK_SUBCOMPONENT )
+
+   id_update       = mpp_clock_id ('  3.6.2-fv_update_phys', flags = clock_flag_default, grain=CLOCK_SUBCOMPONENT )
+   id_fv_diag      = mpp_clock_id ('  3.6.2-fv_diag',        flags = clock_flag_default, grain=CLOCK_SUBCOMPONENT )
+   id_update_other = mpp_clock_id ('  3.6.3-other',          flags = clock_flag_default, grain=CLOCK_SUBCOMPONENT )
 
                     call timing_off('ATMOS_INIT')
 
@@ -663,7 +668,7 @@ contains
    
 !---- Call FV dynamics -----
 
-   call mpp_clock_begin (id_dynam)
+   call mpp_clock_begin(id_dynam_other)
 
    n = mytile
 
@@ -688,6 +693,9 @@ contains
      call read_new_bc_data(Atm(n), Time, Time_step_atmos, p_split, &
                            isd, ied, jsd, jed )
    endif
+   call mpp_clock_end(id_dynam_other)
+
+   call mpp_clock_begin(id_dynam)
 
    do psc=1,abs(p_split)
      !$ser verbatim if (psc == abs(p_split) .and. a_step == 1) then                    
@@ -752,13 +760,13 @@ contains
       endif
 
     end do !p_split
-    call mpp_clock_end (id_dynam)
+    call mpp_clock_end(id_dynam)
 
 !-----------------------------------------------------
 !--- COMPUTE SUBGRID Z
 !-----------------------------------------------------
 !--- zero out tendencies
-    call mpp_clock_begin (id_subgridz)
+    call mpp_clock_begin(id_subgridz)
     u_dt(:,:,:)   = 0.
     v_dt(:,:,:)   = 0.
     t_dt(:,:,:)   = 0.
@@ -800,7 +808,7 @@ contains
     endif
 #endif
 
-   call mpp_clock_end (id_subgridz)
+   call mpp_clock_end(id_subgridz)
 
  end subroutine atmosphere_dynamics
 
@@ -1510,6 +1518,9 @@ contains
    integer :: i, j, ix, k, k1, n, w_diff, nt_dyn, iq
    integer :: nb, blen, nwat, dnats, nq_adv
    real(kind=kind_phys):: rcp, q0, qwat(nq), qt, rdt
+
+   call mpp_clock_begin(id_update_other)
+
    Time_prev = Time
    Time_next = Time + Time_step_atmos
    rdt = 1.d0 / dt_atmos
@@ -1678,8 +1689,9 @@ contains
        enddo
     endif
 #endif
+   call mpp_clock_end(id_update_other)
 
-   call mpp_clock_begin (id_dynam)
+   call mpp_clock_begin(id_update)
        call timing_on('FV_UPDATE_PHYS')
     call fv_update_phys( dt_atmos, isc, iec, jsc, jec, isd, ied, jsd, jed, Atm(n)%ng, nt_dyn, &
                          Atm(n)%u,  Atm(n)%v,   Atm(n)%w,  Atm(n)%delp, Atm(n)%pt,         &
@@ -1696,7 +1708,9 @@ contains
                          Atm(n)%column_moistening_implied_by_nudging)
 
        call timing_off('FV_UPDATE_PHYS')
-   call mpp_clock_end (id_dynam)
+   call mpp_clock_end(id_update)
+
+   call mpp_clock_begin(id_update_other)
 
    if (Atm(n)%flagstruct%nudge) call update_physics_precipitation_for_qv_nudging(Atm_block, IPD_Data)
 
@@ -1708,6 +1722,8 @@ contains
        call timing_off('TWOWAY_UPDATE')
     endif   
    call nullify_domain()
+
+   call mpp_clock_end(id_update_other)
 
   !---- diagnostics for FV dynamics -----
    if (Atm(mytile)%flagstruct%print_freq /= -99) then

--- a/FV3/atmos_cubed_sphere/driver/fvGFS/atmosphere.F90
+++ b/FV3/atmos_cubed_sphere/driver/fvGFS/atmosphere.F90
@@ -476,12 +476,12 @@ contains
     call get_eta_level ( npz, ps2, pref(1,2), dum1d, Atm(mytile)%ak, Atm(mytile)%bk )
 
 !  --- initialize clocks for dynamics, physics_down and physics_up
-   id_dynam        = mpp_clock_id ('  3.1.1-fv_dynamics()', flags = clock_flag_default, grain=CLOCK_SUBCOMPONENT )
-   id_subgridz     = mpp_clock_id ('  3.1.2-fv_subgrid_z()',  flags = clock_flag_default, grain=CLOCK_SUBCOMPONENT )
+   id_dynam        = mpp_clock_id ('  3.1.1-fv_dynamics', flags = clock_flag_default, grain=CLOCK_SUBCOMPONENT )
+   id_subgridz     = mpp_clock_id ('  3.1.2-fv_subgrid_z',  flags = clock_flag_default, grain=CLOCK_SUBCOMPONENT )
    id_dynam_other  = mpp_clock_id ('  3.1.3-Other',      flags = clock_flag_default, grain=CLOCK_SUBCOMPONENT )
 
-   id_update       = mpp_clock_id ('  3.6.1-fv_update_phys()', flags = clock_flag_default, grain=CLOCK_SUBCOMPONENT )
-   id_fv_diag      = mpp_clock_id ('  3.6.2-fv_diag()',        flags = clock_flag_default, grain=CLOCK_SUBCOMPONENT )
+   id_update       = mpp_clock_id ('  3.6.1-fv_update_phys', flags = clock_flag_default, grain=CLOCK_SUBCOMPONENT )
+   id_fv_diag      = mpp_clock_id ('  3.6.2-fv_diag',        flags = clock_flag_default, grain=CLOCK_SUBCOMPONENT )
    id_update_other = mpp_clock_id ('  3.6.3-Other',          flags = clock_flag_default, grain=CLOCK_SUBCOMPONENT )
 
                     call timing_off('ATMOS_INIT')

--- a/FV3/atmos_cubed_sphere/driver/fvGFS/atmosphere.F90
+++ b/FV3/atmos_cubed_sphere/driver/fvGFS/atmosphere.F90
@@ -1,4 +1,4 @@
-
+./FV3/atmos_cubed_sphere/driver/fvGFS/atmosphere.F90
 !***********************************************************************
 !*                   GNU Lesser General Public License                 
 !*
@@ -477,13 +477,13 @@ contains
     call get_eta_level ( npz, ps2, pref(1,2), dum1d, Atm(mytile)%ak, Atm(mytile)%bk )
 
 !  --- initialize clocks for dynamics, physics_down and physics_up
-   id_dynam        = mpp_clock_id ('  3.1.1-fv_dyncore', flags = clock_flag_default, grain=CLOCK_SUBCOMPONENT )
-   id_subgridz     = mpp_clock_id ('  3.1.2-subgrid_z',  flags = clock_flag_default, grain=CLOCK_SUBCOMPONENT )
-   id_dynam_other  = mpp_clock_id ('  3.1.3-other',      flags = clock_flag_default, grain=CLOCK_SUBCOMPONENT )
+   id_dynam        = mpp_clock_id ('  3.1.1-fv_dynamics()', flags = clock_flag_default, grain=CLOCK_SUBCOMPONENT )
+   id_subgridz     = mpp_clock_id ('  3.1.2-fv_subgrid_z()',  flags = clock_flag_default, grain=CLOCK_SUBCOMPONENT )
+   id_dynam_other  = mpp_clock_id ('  3.1.3-Other',      flags = clock_flag_default, grain=CLOCK_SUBCOMPONENT )
 
-   id_update       = mpp_clock_id ('  3.6.1-fv_update_phys', flags = clock_flag_default, grain=CLOCK_SUBCOMPONENT )
-   id_fv_diag      = mpp_clock_id ('  3.6.2-fv_diag',        flags = clock_flag_default, grain=CLOCK_SUBCOMPONENT )
-   id_update_other = mpp_clock_id ('  3.6.3-other',          flags = clock_flag_default, grain=CLOCK_SUBCOMPONENT )
+   id_update       = mpp_clock_id ('  3.6.1-fv_update_phys()', flags = clock_flag_default, grain=CLOCK_SUBCOMPONENT )
+   id_fv_diag      = mpp_clock_id ('  3.6.2-fv_diag()',        flags = clock_flag_default, grain=CLOCK_SUBCOMPONENT )
+   id_update_other = mpp_clock_id ('  3.6.3-Other',          flags = clock_flag_default, grain=CLOCK_SUBCOMPONENT )
 
                     call timing_off('ATMOS_INIT')
 

--- a/FV3/atmos_cubed_sphere/driver/fvGFS/atmosphere.F90
+++ b/FV3/atmos_cubed_sphere/driver/fvGFS/atmosphere.F90
@@ -481,7 +481,7 @@ contains
    id_subgridz     = mpp_clock_id ('  3.1.2-subgrid_z',  flags = clock_flag_default, grain=CLOCK_SUBCOMPONENT )
    id_dynam_other  = mpp_clock_id ('  3.1.3-other',      flags = clock_flag_default, grain=CLOCK_SUBCOMPONENT )
 
-   id_update       = mpp_clock_id ('  3.6.2-fv_update_phys', flags = clock_flag_default, grain=CLOCK_SUBCOMPONENT )
+   id_update       = mpp_clock_id ('  3.6.1-fv_update_phys', flags = clock_flag_default, grain=CLOCK_SUBCOMPONENT )
    id_fv_diag      = mpp_clock_id ('  3.6.2-fv_diag',        flags = clock_flag_default, grain=CLOCK_SUBCOMPONENT )
    id_update_other = mpp_clock_id ('  3.6.3-other',          flags = clock_flag_default, grain=CLOCK_SUBCOMPONENT )
 

--- a/FV3/atmos_cubed_sphere/driver/fvGFS/atmosphere.F90
+++ b/FV3/atmos_cubed_sphere/driver/fvGFS/atmosphere.F90
@@ -1,4 +1,3 @@
-./FV3/atmos_cubed_sphere/driver/fvGFS/atmosphere.F90
 !***********************************************************************
 !*                   GNU Lesser General Public License                 
 !*

--- a/FV3/atmos_cubed_sphere/model/fv_dynamics.F90
+++ b/FV3/atmos_cubed_sphere/model/fv_dynamics.F90
@@ -306,13 +306,13 @@ contains
     integer, save :: id_dyn_core = -1, id_tracer_adv = -1, id_remap = -1, id_other = -1
 
     if (id_dyn_core < 0) &
-        id_dyn_core = mpp_clock_id('  3.1.1.1-dyn_core', flags = clock_flag_default, grain=CLOCK_MODULE)
+        id_dyn_core = mpp_clock_id('   3.1.1.1-dyn_core', flags = clock_flag_default, grain=CLOCK_MODULE)
     if (id_tracer_adv < 0) &
-        id_tracer_adv = mpp_clock_id('  3.1.1.2-tracer', flags = clock_flag_default, grain=CLOCK_MODULE)
+        id_tracer_adv = mpp_clock_id('   3.1.1.2-tracer', flags = clock_flag_default, grain=CLOCK_MODULE)
     if (id_remap < 0) &
-        id_remap = mpp_clock_id('  3.1.1.3-remap', flags = clock_flag_default, grain=CLOCK_MODULE)
+        id_remap = mpp_clock_id('   3.1.1.3-remap', flags = clock_flag_default, grain=CLOCK_MODULE)
     if (id_other < 0) &
-        id_other = mpp_clock_id('  3.1.1.4-other', flags = clock_flag_default, grain=CLOCK_MODULE)
+        id_other = mpp_clock_id('   3.1.1.4-other', flags = clock_flag_default, grain=CLOCK_MODULE)
     call mpp_clock_begin(id_other)
 
       is  = bd%is

--- a/FV3/atmos_cubed_sphere/model/fv_dynamics.F90
+++ b/FV3/atmos_cubed_sphere/model/fv_dynamics.F90
@@ -306,13 +306,13 @@ contains
     integer, save :: id_dyn_core = -1, id_tracer_adv = -1, id_remap = -1, id_other = -1
 
     if (id_dyn_core < 0) &
-        id_dyn_core = mpp_clock_id('   3.1.1.1-dyn_core', flags = clock_flag_default, grain=CLOCK_MODULE)
+        id_dyn_core = mpp_clock_id('   3.1.1.1-dyn_core()', flags = clock_flag_default, grain=CLOCK_MODULE)
     if (id_tracer_adv < 0) &
-        id_tracer_adv = mpp_clock_id('   3.1.1.2-tracer', flags = clock_flag_default, grain=CLOCK_MODULE)
+        id_tracer_adv = mpp_clock_id('   3.1.1.2-Tracer-advection', flags = clock_flag_default, grain=CLOCK_MODULE)
     if (id_remap < 0) &
-        id_remap = mpp_clock_id('   3.1.1.3-remap', flags = clock_flag_default, grain=CLOCK_MODULE)
+        id_remap = mpp_clock_id('   3.1.1.3-lagrangian_to_eulerian()', flags = clock_flag_default, grain=CLOCK_MODULE)
     if (id_other < 0) &
-        id_other = mpp_clock_id('   3.1.1.4-other', flags = clock_flag_default, grain=CLOCK_MODULE)
+        id_other = mpp_clock_id('   3.1.1.4-Other', flags = clock_flag_default, grain=CLOCK_MODULE)
     call mpp_clock_begin(id_other)
 
       is  = bd%is

--- a/FV3/atmos_cubed_sphere/model/fv_dynamics.F90
+++ b/FV3/atmos_cubed_sphere/model/fv_dynamics.F90
@@ -306,11 +306,11 @@ contains
     integer, save :: id_dyn_core = -1, id_tracer_adv = -1, id_remap = -1, id_other = -1
 
     if (id_dyn_core < 0) &
-        id_dyn_core = mpp_clock_id('   3.1.1.1-dyn_core()', flags = clock_flag_default, grain=CLOCK_MODULE)
+        id_dyn_core = mpp_clock_id('   3.1.1.1-dyn_core', flags = clock_flag_default, grain=CLOCK_MODULE)
     if (id_tracer_adv < 0) &
         id_tracer_adv = mpp_clock_id('   3.1.1.2-Tracer-advection', flags = clock_flag_default, grain=CLOCK_MODULE)
     if (id_remap < 0) &
-        id_remap = mpp_clock_id('   3.1.1.3-lagrangian_to_eulerian()', flags = clock_flag_default, grain=CLOCK_MODULE)
+        id_remap = mpp_clock_id('   3.1.1.3-Remapping', flags = clock_flag_default, grain=CLOCK_MODULE)
     if (id_other < 0) &
         id_other = mpp_clock_id('   3.1.1.4-Other', flags = clock_flag_default, grain=CLOCK_MODULE)
     call mpp_clock_begin(id_other)

--- a/FV3/atmos_cubed_sphere/model/fv_dynamics.F90
+++ b/FV3/atmos_cubed_sphere/model/fv_dynamics.F90
@@ -147,8 +147,11 @@ module fv_dynamics_mod
    use fv_arrays_mod,       only: fv_grid_type, fv_flags_type, fv_atmos_type, fv_nest_type, fv_diag_type, fv_grid_bounds_type
    use fv_nwp_nudge_mod,    only: do_adiabatic_init
 #ifdef MULTI_GASES
-   use multi_gases_mod,  only:  virq, virqd, vicpqd
+   use multi_gases_mod,     only:  virq, virqd, vicpqd
 #endif
+  use mpp_mod,              only: mpp_clock_id, mpp_clock_begin,     &
+                                  mpp_clock_end, CLOCK_MODULE
+  use fms_mod,              only: clock_flag_default
 
 implicit none
    logical :: RF_initialized = .false.
@@ -299,6 +302,18 @@ contains
                                  last_step => CCPP_interstitial%last_step, &
                                  te_2d     => CCPP_interstitial%te0_2d     )
 #endif
+
+    integer, save :: id_dyn_core = -1, id_tracer_adv = -1, id_remap = -1, id_other = -1
+
+    if (id_dyn_core < 0) &
+        id_dyn_core = mpp_clock_id('  3.1.1.1-dyn_core', flags = clock_flag_default, grain=CLOCK_MODULE)
+    if (id_tracer_adv < 0) &
+        id_tracer_adv = mpp_clock_id('  3.1.1.2-tracer', flags = clock_flag_default, grain=CLOCK_MODULE)
+    if (id_remap < 0) &
+        id_remap = mpp_clock_id('  3.1.1.3-remap', flags = clock_flag_default, grain=CLOCK_MODULE)
+    if (id_other < 0) &
+        id_other = mpp_clock_id('  3.1.1.4-other', flags = clock_flag_default, grain=CLOCK_MODULE)
+    call mpp_clock_begin(id_other)
 
       is  = bd%is
       ie  = bd%ie
@@ -652,8 +667,11 @@ contains
        enddo
   endif
 #endif
+  call mpp_clock_end(id_other)
+
                                                   call timing_on('FV_DYN_LOOP')
   do n_map=1, k_split   ! first level of time-split
+     call mpp_clock_begin(id_dyn_core)
      !$ser verbatim n_map_step=n_map
      k_step = n_map
     
@@ -717,6 +735,9 @@ contains
       !$ser savepoint DynCore-Out
       !$ser data cappa=cappa u=u v=v w=w delz=delz pt=pt delp=delp pe=pe pk=pk phis=phis wsd=ws omga=omga ptop=ptop pfull=pfull ua=ua va=va uc=uc vc=vc mfxd=mfx mfyd=mfy cxd=cx cyd=cy pkz=pkz peln=peln q_con=q_con diss_estd=diss_est  
 
+     call mpp_clock_end(id_dyn_core)
+     call mpp_clock_begin(id_tracer_adv)
+
 #ifdef SW_DYNAMICS
 !!$OMP parallel do default(none) shared(is,ie,js,je,ps,delp,agrav)
       do j=js,je
@@ -776,6 +797,9 @@ contains
          endif
       endif
      
+      call mpp_clock_end(id_tracer_adv)
+      call mpp_clock_begin(id_remap)
+
       if ( npz > 4 ) then
 !------------------------------------------------------------------------
 ! Perform vertical remapping from Lagrangian control-volume to
@@ -852,11 +876,15 @@ contains
             endif
          endif
       end if
-      
+
+      call mpp_clock_end(id_remap)
+
 #endif
   enddo    ! n_map loop
                                                   call timing_off('FV_DYN_LOOP')
- 
+
+  call mpp_clock_begin(id_other)
+
   if ( idiag%id_mdt > 0 .and. (.not.do_adiabatic_init) ) then
 ! Output temperature tendency due to inline moist physics:
 #if defined(CCPP) && defined(__GFORTRAN__)
@@ -1045,6 +1073,7 @@ contains
 #ifdef CCPP
   end associate ccpp_associate
 #endif
+  call mpp_clock_end(id_other)
 
   end subroutine fv_dynamics
 

--- a/FV3/atmos_model.F90
+++ b/FV3/atmos_model.F90
@@ -768,15 +768,15 @@ subroutine atmos_model_init (Atmos, Time_init, Time, Time_step)
 #endif
 
    if (sync) then
-     fv3Clock = mpp_clock_id( ' 3.1-FV3-Dycore', flags=clock_flag_default+MPP_CLOCK_SYNC, grain=CLOCK_COMPONENT )
+     fv3Clock = mpp_clock_id( ' 3.1-atmosphere_dynamics()', flags=clock_flag_default+MPP_CLOCK_SYNC, grain=CLOCK_COMPONENT )
    else
-     fv3Clock = mpp_clock_id( ' 3.1-FV3-Dycore', flags=clock_flag_default, grain=CLOCK_COMPONENT )
+     fv3Clock = mpp_clock_id( ' 3.1-atmosphere_dynamics()', flags=clock_flag_default, grain=CLOCK_COMPONENT )
    endif
-   getClock   = mpp_clock_id( ' 3.2-FV3-Get-state', flags=clock_flag_default, grain=CLOCK_COMPONENT )
+   getClock   = mpp_clock_id( ' 3.2-atmos_phys_driver_statein()', flags=clock_flag_default, grain=CLOCK_COMPONENT )
    setupClock = mpp_clock_id( ' 3.3-GFS-Step-Setup', flags=clock_flag_default, grain=CLOCK_COMPONENT )
    radClock   = mpp_clock_id( ' 3.4-GFS-Radiation', flags=clock_flag_default, grain=CLOCK_COMPONENT )
    physClock  = mpp_clock_id( ' 3.5-GFS-Physics', flags=clock_flag_default, grain=CLOCK_COMPONENT )
-   updClock   = mpp_clock_id( ' 3.6-FV3-Update-state', flags=clock_flag_default, grain=CLOCK_COMPONENT )
+   updClock   = mpp_clock_id( ' 3.6-atmosphere_state_update()', flags=clock_flag_default, grain=CLOCK_COMPONENT )
    diagClock  = mpp_clock_id( ' 3.7-Diagnostics', flags=clock_flag_default, grain=CLOCK_COMPONENT )
    ! 3.8-Write-restart is timed on the coupler_main.F90 level
    otherClock = mpp_clock_id( ' 3.9-Other', flags=clock_flag_default, grain=CLOCK_COMPONENT )
@@ -899,12 +899,9 @@ subroutine update_atmos_model_state (Atmos)
     call set_atmosphere_pelist()
     call mpp_clock_end(otherClock)
 
-    ! OF: remove fv3Clock timer here in order to avoid double-counting
-    !call mpp_clock_begin(fv3Clock)
     call mpp_clock_begin(updClock)
     call atmosphere_state_update (Atmos%Time, IPD_Data, IAU_Data, Atm_block, flip_vc)
     call mpp_clock_end(updClock)
-    !call mpp_clock_end(fv3Clock)
 
     call mpp_clock_begin(otherClock)
     if (chksum_debug) then

--- a/FV3/atmos_model.F90
+++ b/FV3/atmos_model.F90
@@ -768,15 +768,15 @@ subroutine atmos_model_init (Atmos, Time_init, Time, Time_step)
 #endif
 
    if (sync) then
-     fv3Clock = mpp_clock_id( ' 3.1-atmosphere_dynamics()', flags=clock_flag_default+MPP_CLOCK_SYNC, grain=CLOCK_COMPONENT )
+     fv3Clock = mpp_clock_id( ' 3.1-atmosphere_dynamics', flags=clock_flag_default+MPP_CLOCK_SYNC, grain=CLOCK_COMPONENT )
    else
-     fv3Clock = mpp_clock_id( ' 3.1-atmosphere_dynamics()', flags=clock_flag_default, grain=CLOCK_COMPONENT )
+     fv3Clock = mpp_clock_id( ' 3.1-atmosphere_dynamics', flags=clock_flag_default, grain=CLOCK_COMPONENT )
    endif
-   getClock   = mpp_clock_id( ' 3.2-atmos_phys_driver_statein()', flags=clock_flag_default, grain=CLOCK_COMPONENT )
+   getClock   = mpp_clock_id( ' 3.2-atmos_phys_driver_statein', flags=clock_flag_default, grain=CLOCK_COMPONENT )
    setupClock = mpp_clock_id( ' 3.3-GFS-Step-Setup', flags=clock_flag_default, grain=CLOCK_COMPONENT )
    radClock   = mpp_clock_id( ' 3.4-GFS-Radiation', flags=clock_flag_default, grain=CLOCK_COMPONENT )
    physClock  = mpp_clock_id( ' 3.5-GFS-Physics', flags=clock_flag_default, grain=CLOCK_COMPONENT )
-   updClock   = mpp_clock_id( ' 3.6-atmosphere_state_update()', flags=clock_flag_default, grain=CLOCK_COMPONENT )
+   updClock   = mpp_clock_id( ' 3.6-atmosphere_state_update', flags=clock_flag_default, grain=CLOCK_COMPONENT )
    diagClock  = mpp_clock_id( ' 3.7-Diagnostics', flags=clock_flag_default, grain=CLOCK_COMPONENT )
    ! 3.8-Write-restart is timed on the coupler_main.F90 level
    otherClock = mpp_clock_id( ' 3.9-Other', flags=clock_flag_default, grain=CLOCK_COMPONENT )

--- a/FV3/atmos_model.F90
+++ b/FV3/atmos_model.F90
@@ -170,7 +170,7 @@ public Atm_block, IPD_Data, IPD_Control
                                                          ! to calculate gradient on cubic sphere grid.
 !</PUBLICTYPE >
 
-integer :: fv3Clock, getClock, updClock, setupClock, radClock, physClock
+integer :: fv3Clock, getClock, updClock, setupClock, radClock, physClock, diagClock, otherClock
 
 !-----------------------------------------------------------------------
 integer :: blocksize    = 1
@@ -279,28 +279,36 @@ subroutine update_atmos_radiation_physics (Atmos)
 
     if (mpp_pe() == mpp_root_pe() .and. debug) write(6,*) "statein driver"
 !--- get atmospheric state from the dynamic core
+
+    call mpp_clock_begin(otherClock)
     call set_atmosphere_pelist()
-    call mpp_clock_begin(getClock)
     if (IPD_control%do_skeb) call atmosphere_diss_est (IPD_control%skeb_npass) !  do smoothing for SKEB
+    call mpp_clock_end(otherClock)
+
+    call mpp_clock_begin(getClock)
     call atmos_phys_driver_statein (IPD_data, Atm_block, flip_vc)
     call mpp_clock_end(getClock)
 
 !--- if dycore only run, set up the dummy physics output state as the input state
     if (dycore_only) then
+      call mpp_clock_begin(updClock)
       do nb = 1,Atm_block%nblks
         IPD_Data(nb)%Stateout%gu0 = IPD_Data(nb)%Statein%ugrs
         IPD_Data(nb)%Stateout%gv0 = IPD_Data(nb)%Statein%vgrs
         IPD_Data(nb)%Stateout%gt0 = IPD_Data(nb)%Statein%tgrs
         IPD_Data(nb)%Stateout%gq0 = IPD_Data(nb)%Statein%qgrs
       enddo
+      call mpp_clock_end(updClock)
     else
       if (mpp_pe() == mpp_root_pe() .and. debug) write(6,*) "setup step"
 
 !--- update IPD_Control%jdat(8)
+      call mpp_clock_begin(otherClock)
       jdat(:) = 0
       call get_date (Atmos%Time, jdat(1), jdat(2), jdat(3),  &
                                  jdat(5), jdat(6), jdat(7))
       IPD_Control%jdat(:) = jdat(:)
+      call mpp_clock_end(otherClock)
 
 !--- execute the IPD atmospheric setup step
       call mpp_clock_begin(setupClock)
@@ -363,10 +371,12 @@ subroutine update_atmos_radiation_physics (Atmos)
 #endif
       call mpp_clock_end(radClock)
 
+      call mpp_clock_begin(otherClock)
       if (chksum_debug) then
         if (mpp_pe() == mpp_root_pe()) print *,'RADIATION STEP  ', IPD_Control%kdt, IPD_Control%fhour
         call FV3GFS_IPD_checksum(IPD_Control, IPD_Data, Atm_block)
       endif
+      call mpp_clock_end(otherClock)
 
       if (mpp_pe() == mpp_root_pe() .and. debug) write(6,*) "physics driver"
 
@@ -388,10 +398,12 @@ subroutine update_atmos_radiation_physics (Atmos)
 #endif
       call mpp_clock_end(physClock)
 
+      call mpp_clock_begin(otherClock)
       if (chksum_debug) then
         if (mpp_pe() == mpp_root_pe()) print *,'PHYSICS STEP1   ', IPD_Control%kdt, IPD_Control%fhour
         call FV3GFS_IPD_checksum(IPD_Control, IPD_Data, Atm_block)
       endif
+      call mpp_clock_end(otherClock)
 
       if (mpp_pe() == mpp_root_pe() .and. debug) write(6,*) "stochastic physics driver"
 
@@ -413,12 +425,14 @@ subroutine update_atmos_radiation_physics (Atmos)
 #endif
       call mpp_clock_end(physClock)
 
+      call mpp_clock_begin(otherClock)
       if (chksum_debug) then
         if (mpp_pe() == mpp_root_pe()) print *,'PHYSICS STEP2   ', IPD_Control%kdt, IPD_Control%fhour
         call FV3GFS_IPD_checksum(IPD_Control, IPD_Data, Atm_block)
       endif
       call getiauforcing(IPD_Control,IAU_data)
       if (mpp_pe() == mpp_root_pe() .and. debug) write(6,*) "end of radiation and physics step"
+      call mpp_clock_end(otherClock)
     endif
 
 #ifdef CCPP
@@ -753,16 +767,19 @@ subroutine atmos_model_init (Atmos, Time_init, Time, Time_step)
    if (mpp_pe() == mpp_root_pe()) write(6,*) "---fdiag",fdiag(1:40)
 #endif
 
-   setupClock = mpp_clock_id( 'GFS Step Setup        ', flags=clock_flag_default, grain=CLOCK_COMPONENT )
-   radClock   = mpp_clock_id( 'GFS Radiation         ', flags=clock_flag_default, grain=CLOCK_COMPONENT )
-   physClock  = mpp_clock_id( 'GFS Physics           ', flags=clock_flag_default, grain=CLOCK_COMPONENT )
-   getClock   = mpp_clock_id( 'Dynamics get state    ', flags=clock_flag_default, grain=CLOCK_COMPONENT )
-   updClock   = mpp_clock_id( 'Dynamics update state ', flags=clock_flag_default, grain=CLOCK_COMPONENT )
    if (sync) then
-     fv3Clock = mpp_clock_id( 'FV3 Dycore            ', flags=clock_flag_default+MPP_CLOCK_SYNC, grain=CLOCK_COMPONENT )
+     fv3Clock = mpp_clock_id( ' 3.1-FV3-Dycore', flags=clock_flag_default+MPP_CLOCK_SYNC, grain=CLOCK_COMPONENT )
    else
-     fv3Clock = mpp_clock_id( 'FV3 Dycore            ', flags=clock_flag_default, grain=CLOCK_COMPONENT )
+     fv3Clock = mpp_clock_id( ' 3.1-FV3-Dycore', flags=clock_flag_default, grain=CLOCK_COMPONENT )
    endif
+   getClock   = mpp_clock_id( ' 3.2-FV3-Get-state', flags=clock_flag_default, grain=CLOCK_COMPONENT )
+   setupClock = mpp_clock_id( ' 3.3-GFS-Step-Setup', flags=clock_flag_default, grain=CLOCK_COMPONENT )
+   radClock   = mpp_clock_id( ' 3.4-GFS-Radiation', flags=clock_flag_default, grain=CLOCK_COMPONENT )
+   physClock  = mpp_clock_id( ' 3.5-GFS-Physics', flags=clock_flag_default, grain=CLOCK_COMPONENT )
+   updClock   = mpp_clock_id( ' 3.6-FV3-Update-state', flags=clock_flag_default, grain=CLOCK_COMPONENT )
+   diagClock  = mpp_clock_id( ' 3.7-Diagnostics', flags=clock_flag_default, grain=CLOCK_COMPONENT )
+   ! 3.8-Write-restart is timed on the coupler_main.F90 level
+   otherClock = mpp_clock_id( ' 3.9-Other', flags=clock_flag_default, grain=CLOCK_COMPONENT )
 
 #ifdef CCPP
    ! Set flag for first time step of time integration
@@ -781,7 +798,10 @@ subroutine update_atmos_model_dynamics (Atmos)
 ! run the atmospheric dynamics to advect the properties
   type (atmos_data_type), intent(in) :: Atmos
 
+    call mpp_clock_begin(otherClock)
     call set_atmosphere_pelist()
+    call mpp_clock_end(otherClock)
+    
     call mpp_clock_begin(fv3Clock)
     call atmosphere_dynamics (Atmos%Time)
     call mpp_clock_end(fv3Clock)
@@ -875,22 +895,29 @@ subroutine update_atmos_model_state (Atmos)
   real(kind=IPD_kind_phys) :: time_int, time_intfull
   integer :: is, ie, js, je, nk
 !
+    call mpp_clock_begin(otherClock)
     call set_atmosphere_pelist()
-    call mpp_clock_begin(fv3Clock)
+    call mpp_clock_end(otherClock)
+
+    ! OF: remove fv3Clock timer here in order to avoid double-counting
+    !call mpp_clock_begin(fv3Clock)
     call mpp_clock_begin(updClock)
     call atmosphere_state_update (Atmos%Time, IPD_Data, IAU_Data, Atm_block, flip_vc)
     call mpp_clock_end(updClock)
-    call mpp_clock_end(fv3Clock)
+    !call mpp_clock_end(fv3Clock)
 
+    call mpp_clock_begin(otherClock)
     if (chksum_debug) then
       if (mpp_pe() == mpp_root_pe()) print *,'UPDATE STATE    ', IPD_Control%kdt, IPD_Control%fhour
       if (mpp_pe() == mpp_root_pe()) print *,'in UPDATE STATE    ', size(IPD_Data(1)%SfcProp%tsfc),'nblks=',Atm_block%nblks
       call FV3GFS_IPD_checksum(IPD_Control, IPD_Data, Atm_block)
     endif
+    call mpp_clock_end(otherClock)
 
     !--- advance time ---
     Atmos % Time = Atmos % Time + Atmos % Time_step
 
+    call mpp_clock_begin(diagClock)
     call get_time (Atmos%Time - diag_time, isec)
     call get_time (Atmos%Time - Atmos%Time_init, seconds)
     call atmosphere_nggps_diag(Atmos%Time,ltavg=.true.,avg_max_length=avg_max_length)
@@ -928,6 +955,9 @@ subroutine update_atmos_model_state (Atmos)
       endif
       call diag_send_complete_instant (Atmos%Time)
     endif
+    call mpp_clock_end(diagClock)
+
+    call mpp_clock_begin(otherClock)
 
     !--- this may not be necessary once write_component is fully implemented
     !!!call diag_send_complete_extra (Atmos%Time)
@@ -941,6 +971,8 @@ subroutine update_atmos_model_state (Atmos)
 !jw       call setup_exportdata(IPD_Control, IPD_Data, Atm_block)
       call setup_exportdata(rc)
     endif
+
+    call mpp_clock_end(otherClock)
 
  end subroutine update_atmos_model_state
 ! </SUBROUTINE>

--- a/FV3/coupler_main.F90
+++ b/FV3/coupler_main.F90
@@ -53,7 +53,9 @@ use       fms_mod,     only: file_exist, check_nml_error,               &
 
 use mpp_mod,           only: mpp_init, mpp_pe, mpp_root_pe, mpp_npes, mpp_get_current_pelist, &
                              mpp_set_current_pelist, stdlog, mpp_error, NOTE, FATAL, WARNING
-use mpp_mod,           only: mpp_clock_id, mpp_clock_begin, mpp_clock_end, mpp_sync
+use mpp_mod,           only: mpp_clock_id, mpp_clock_begin, mpp_clock_end, mpp_sync, &
+                             mpp_record_time_start, mpp_record_time_end, CLOCK_COMPONENT
+use fms_mod,           only: clock_flag_default
 
 use mpp_io_mod,        only: mpp_open, mpp_close, &
                              MPP_NATIVE, MPP_RDONLY, MPP_DELETE
@@ -95,7 +97,7 @@ character(len=128) :: tag = '$Name: ulm_201505 $'
 
 ! ----- timing flags -----
 
-   integer :: initClock, mainClock, termClock
+   integer :: initClock = -1, mainClock = -1, termClock = -1, mainClock1st = -1, rstrtClock = -1
    integer, parameter :: timing_level = 1
 
 ! ----- namelist -----
@@ -128,7 +130,7 @@ character(len=128) :: tag = '$Name: ulm_201505 $'
 
  call fms_init()
  call mpp_init()
- initClock = mpp_clock_id( 'Initialization' )
+ initClock = mpp_clock_id( '1-Initialization' )
  call mpp_clock_begin (initClock) !nesting problem
   
  call fms_init
@@ -150,11 +152,22 @@ character(len=128) :: tag = '$Name: ulm_201505 $'
 
  call mpp_set_current_pelist()
  call mpp_clock_end (initClock) !end initialization
- mainClock = mpp_clock_id( 'Main loop' )
- termClock = mpp_clock_id( 'Termination' )
- call mpp_clock_begin(mainClock) !begin main loop
+ mainClock1st = mpp_clock_id( '2-Main-loop-1st-trip' )
+ mainClock = mpp_clock_id( '3-Main-loop' )
+ rstrtClock = mpp_clock_id( ' 3.8-Write-restart', flags=clock_flag_default, grain=CLOCK_COMPONENT )
+ termClock = mpp_clock_id( '4-Termination' )
+
+ call mpp_clock_begin(mainClock1st)
+ call mpp_record_time_end()
 
  do nc = 1, num_cpld_calls
+
+    ! separate timer for first trip of timeloop (due to init overhead)
+    if (nc > 1) then
+      call mpp_record_time_start()
+      call mpp_clock_end(mainClock1st)
+      call mpp_clock_begin(mainClock)
+    end if
 
     Time_atmos = Time_atmos + Time_step_atmos
 
@@ -165,6 +178,7 @@ character(len=128) :: tag = '$Name: ulm_201505 $'
     call update_atmos_model_state (Atm)
 
 !--- intermediate restart
+    call mpp_clock_begin(rstrtClock)
     if (intrm_rst) then
       if ((nc /= num_cpld_calls) .and. (Time_atmos == Time_restart)) then
         timestamp = date_to_string (Time_restart)
@@ -173,6 +187,7 @@ character(len=128) :: tag = '$Name: ulm_201505 $'
         Time_restart = Time_restart + Time_step_restart
       endif
     endif
+    call mpp_clock_end(rstrtClock)
 
     call print_memuse_stats('after full step')
 
@@ -183,10 +198,17 @@ character(len=128) :: tag = '$Name: ulm_201505 $'
 #ifdef AVEC_TIMERS
  call avec_timers_output
 #endif
- call mpp_set_current_pelist()
- call mpp_clock_end(mainClock)
- call mpp_clock_begin(termClock)
 
+ call mpp_set_current_pelist()
+ 
+ if (num_cpld_calls > 1) then
+   call mpp_clock_end(mainClock)
+ else
+    call mpp_record_time_start()
+    call mpp_clock_end(mainClock1st)
+ end if
+
+ call mpp_clock_begin(termClock)
  call coupler_end
  call mpp_set_current_pelist()
  call mpp_clock_end(termClock)

--- a/FV3/coupler_main.F90
+++ b/FV3/coupler_main.F90
@@ -132,6 +132,7 @@ character(len=128) :: tag = '$Name: ulm_201505 $'
  call mpp_init()
  initClock = mpp_clock_id( '1-Initialization' )
  call mpp_clock_begin (initClock) !nesting problem
+ call mpp_record_time_end()
   
  call fms_init
  call constants_init
@@ -151,6 +152,7 @@ character(len=128) :: tag = '$Name: ulm_201505 $'
  call print_memuse_stats('after coupler init')
 
  call mpp_set_current_pelist()
+ call mpp_record_time_start()
  call mpp_clock_end (initClock) !end initialization
  mainClock1st = mpp_clock_id( '2-Main-loop-1st-trip' )
  mainClock = mpp_clock_id( '3-Main-loop' )
@@ -209,8 +211,10 @@ character(len=128) :: tag = '$Name: ulm_201505 $'
  end if
 
  call mpp_clock_begin(termClock)
+ call mpp_record_time_end()
  call coupler_end
  call mpp_set_current_pelist()
+ call mpp_record_time_start()
  call mpp_clock_end(termClock)
 
  call fms_end


### PR DESCRIPTION
This PR introduces some modifications to the FMS timers present in the model (main API is `mpp_clock_id(), mpp_clock_begin(), mpp_clock_end()`). Since we want to make more detailed comparisons between the Fortran and Python version, it is important that these timings are easy to understand (no overlap, full coverage) and easy to process (parseable). This PR contains the following modifications:
- Avoid untimed sections (sub-sections should always add up to higher-level section)
- Split off timing of 1st trip through main loop (since it's polluted by initialization and memory allocations)
- Remove `atmosphere_state_update()` from FV3 Dycore timer and introduce separate timer to capture it.
- Introduce additional more fine-grain sections in FV3 (dyn_core, tracer, remap).
- Easier to parse section names (no spaces)
- Added hit count (2nd column) how many times a timing section is encountered

Example output in stdout (sorted manually):
```
[0] Tabulating mpp_clock statistics across      6 PEs...
[0]
[0]                                       hits          tmin          tmax          tavg          tstd  tfrac grain pemin pemax
[0] Total runtime                            1     54.180617     54.180985     54.180826      0.000155  1.000     0     0     5
[0] 1-Initialization                         1     29.744163     29.753218     29.749717      0.003259  0.549     0     0     5
[0] 2-Main-loop-1st-trip                     1     16.219054     16.220346     16.219669      0.000427  0.299     0     0     5
[0] 3-Main-loop                              1      7.611644      7.612934      7.612316      0.000430  0.140     0     0     5
[0]  3.1-atmosphere_dynamics                 1      7.269450      7.270743      7.270121      0.000445  0.134     1     0     5
[0]   3.1.1-fv_dynamics                      1      7.268773      7.270060      7.269427      0.000428  0.134    11     0     5
[0]   3.1.2-fv_subgrid_z                     1      0.000670      0.000768      0.000690      0.000035  0.000    11     0     5
[0]   3.1.3-Other                            1      0.000000      0.000001      0.000001      0.000000  0.000    11     0     5
[0]  3.2-atmos_phys_driver_statein           1      0.007353      0.008806      0.008256      0.000471  0.000     1     0     5
[0]  3.3-GFS-Step-Setup                      1      0.001941      0.003257      0.002646      0.000497  0.000     1     0     5
[0]  3.4-GFS-Radiation                       1      0.002465      0.002978      0.002754      0.000198  0.000     1     0     5
[0]  3.5-GFS-Physics                         2      0.072790      0.075840      0.074956      0.001039  0.001     1     0     5
[0]  3.6-atmosphere_state_update             1      0.224561      0.234258      0.229844      0.003123  0.004     1     0     5
[0]   3.6.1-fv_update_phys                   1      0.130028      0.165595      0.153412      0.012183  0.003    11     0     5
[0]   3.6.2-fv_diag                          1      0.050709      0.075975      0.066855      0.008527  0.001    11     0     5
[0]   3.6.3-Other                            2      0.002688      0.043821      0.009574      0.015316  0.000    11     0     5
[0]    3.1.1.1-dyn_core                      1      6.812148      6.886048      6.859292      0.026267  0.127    31     0     5
[0]    3.1.1.2-Tracer-advection              1      0.300183      0.326132      0.315707      0.008434  0.006    31     0     5
[0]    3.1.1.3-Remapping                     1      0.056074      0.056256      0.056168      0.000064  0.001    31     0     5
[0]    3.1.1.4-Other                         2      0.013695      0.075488      0.038215      0.025516  0.001    31     0     5
[0]  3.7-Diagnostics                         1      0.010125      0.023176      0.015954      0.005420  0.000     1     0     5
[0]  3.8-Write-restart                       1      0.000000      0.000000      0.000000      0.000000  0.000     1     0     5
[0]  3.9-Other                               9      0.000124      0.000264      0.000160      0.000050  0.000     1     0     5
[0] 4-Termination                            1      0.552310      0.557486      0.554090      0.002399  0.010     0     0     5
```

Unfortunately, there seems to be no easy way to enforce a certain ordering of the timer output to stdout. A solution would be to define the timers globally, leading to redundancy in the definition and being error prone. Any suggestions from the reviewers are highly welcome.