### PR TITLE
pin the gcloud version for circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  gcp-cli: circleci/gcp-cli@2.1.0
+  gcp-cli: circleci/gcp-cli@1.0.0
   gcp-gcr: circleci/gcp-gcr@0.6.1
 jobs:
   build_default:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  gcp-cli: circleci/gcp-cli@1.0.0
+  gcp-cli: circleci/gcp-cli@2.1.0
   gcp-gcr: circleci/gcp-gcr@0.6.1
 jobs:
   build_default:
@@ -11,6 +11,8 @@ jobs:
       FV3CONFIG_CACHE_DIR: /tmp/.fv3config
       GOOGLE_APPLICATION_CREDENTIALS: /tmp/key.json
     steps:
+      - gcp-cli/install:
+        version: 323.0.0
       - checkout
       - run:
           name: "gcloud auth"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,6 @@
 version: 2.1
 orbs:
+  gcp-cli: circleci/gcp-cli@2.1.0
   gcp-gcr: circleci/gcp-gcr@0.6.1
 jobs:
   build_default:


### PR DESCRIPTION
We noticed the cloud sdk version changed over the weekend from 323.0.0 to 324.0.0.  It appears to be the reason why circle ci no longer has permissions to set the zone for the node it is running on. An alternative option to this PR is to give the Compute Viewer role to all of the fv3gfs-fort-gcp-ci service accounts, which would happen in a different repo or by hand. Here we pin the version of gcloud used by adding the gcp-cli orb and forcing the gcloud version to 323.0.0.  