### PR TITLE
Revert `fill_dp=.false.` for c12 and c48 standard namelists

### DIFF
--- a/FV3/atmos_cubed_sphere/model/dyn_core.F90
+++ b/FV3/atmos_cubed_sphere/model/dyn_core.F90
@@ -2369,6 +2369,9 @@ do 1000 j=jfirst,jlast
       dpmin = 0.01 * ( ak(k+1)-ak(k) + (bk(k+1)-bk(k))*1.E5 )
       do i=ifirst, ilast
          if(delp(i,j,k) < dpmin) then
+#ifdef SERIALIZE
+            stop 'Encountered gridpoint where mix_dp() is applied. Not ported in fv3core!'
+#endif
             if (fv_debug) write(*,*) 'Mix_dp: ', i, j, k, mpp_pe(), delp(i,j,k), pt(i,j,k)
             ! Remap from below and mix pt
             dp = dpmin - delp(i,j,k)
@@ -2386,7 +2389,10 @@ do 1000 j=jfirst,jlast
    do i=ifirst, ilast
       if(delp(i,j,km) < dpmin) then
          if (fv_debug) write(*,*) 'Mix_dp: ', i, j, km, mpp_pe(), delp(i,j,km), pt(i,j,km)
-         ! Remap from above and mix pt
+#ifdef SERIALIZE
+         stop 'Encountered gridpoint where mix_dp() is applied. Not ported in fv3core!'
+#endif
+      ! Remap from above and mix pt
          dp = dpmin - delp(i,j,km)
          pt(i,j,km) = (pt(i,j,km)*delp(i,j,km) + pt(i,j,km-1)*dp)/dpmin
          if ( .not.hydrostatic ) w(i,j,km) = (w(i,j,km)*delp(i,j,km) + w(i,j,km-1)*dp) / dpmin

--- a/tests/serialized_test_data_generation/Makefile
+++ b/tests/serialized_test_data_generation/Makefile
@@ -10,7 +10,7 @@ SER_ENV ?= ALL
 # -convention: <tag>-<some large conceptual version change>.<serialization statement change>.<hotfix>
 # -version number should be increased when serialization data is expected to change
 # -omit tag (e.g. 7.1.1) for "operational" serialization data, use tag for experimental serialization data
-FORTRAN_VERSION ?= 7.2.4
+FORTRAN_VERSION ?= 7.2.3
 # docker container image setup (used for running model, see ../../README.md)
 GCR_URL = us.gcr.io/vcm-ml
 COMPILED_IMAGE = $(GCR_URL)/fv3gfs-compiled:$(FORTRAN_VERSION)-serialize-gt4pydev

--- a/tests/serialized_test_data_generation/configs/c12_54ranks_standard.yml
+++ b/tests/serialized_test_data_generation/configs/c12_54ranks_standard.yml
@@ -120,7 +120,7 @@ namelist:
     dwind_2d: false
     external_ic: true
     fill: true
-    fill_dp: false
+    fill_dp: true
     fv_debug: false
     fv_sg_adj: 600
     gfs_phil: false

--- a/tests/serialized_test_data_generation/configs/c12_6ranks_standard.yml
+++ b/tests/serialized_test_data_generation/configs/c12_6ranks_standard.yml
@@ -120,7 +120,7 @@ namelist:
     dwind_2d: false
     external_ic: true
     fill: true
-    fill_dp: false
+    fill_dp: true
     fv_debug: false
     fv_sg_adj: 600
     gfs_phil: false

--- a/tests/serialized_test_data_generation/configs/c48_6ranks_standard.yml
+++ b/tests/serialized_test_data_generation/configs/c48_6ranks_standard.yml
@@ -120,7 +120,7 @@ namelist:
     dwind_2d: false
     external_ic: true
     fill: true
-    fill_dp: false
+    fill_dp: true
     fv_debug: false
     fv_sg_adj: 600
     gfs_phil: false


### PR DESCRIPTION
Reverts a recent change to the c12 and c48 standard namelists, since disabling `fill_dp` crashes these setups when run for a longer time period (e.g. 1 day).