### PR TITLE
Feature/set stacksize

### DIFF
--- a/tests/serialized_test_data_generation/configs/c192_6ranks_baroclinic.yml
+++ b/tests/serialized_test_data_generation/configs/c192_6ranks_baroclinic.yml
@@ -100,7 +100,7 @@ namelist:
     max_files_w: 100
   fms_nml:
     clock_grain: ROUTINE
-    domains_stack_size: 3000000
+    domains_stack_size: 16000000
     print_memory_usage: false
   fv_core_nml:
     a_imp: 1.0

--- a/tests/serialized_test_data_generation/configs/c256_6ranks_baroclinic.yml
+++ b/tests/serialized_test_data_generation/configs/c256_6ranks_baroclinic.yml
@@ -100,7 +100,7 @@ namelist:
     max_files_w: 100
   fms_nml:
     clock_grain: ROUTINE
-    domains_stack_size: 3000000
+    domains_stack_size: 16000000
     print_memory_usage: false
   fv_core_nml:
     a_imp: 1.0

--- a/tests/serialized_test_data_generation/submit_job.sh
+++ b/tests/serialized_test_data_generation/submit_job.sh
@@ -17,7 +17,8 @@ mkdir -p $TEST_DATA_DIR
 # a single node. The alternative is to set --shm-size in the docker
 # run command.
 export MPIR_CVAR_CH3_NOLOCAL=1
-
+# Setting this to allow finer resolution on 1 rank
+export OMP_STACKSIZE=10G
 
 # setup run environment
 cd $RUNDIR


### PR DESCRIPTION
This PR updates the domain_set_stacksize namelist option for some larger runs and the default OMP stacksize in Jenkins so we don't generate stack overflows