### PR TITLE
Raise error for misconfigured field_tables

### DIFF
--- a/FV3/gfsphysics/GFS_layer/GFS_typedefs.F90
+++ b/FV3/gfsphysics/GFS_layer/GFS_typedefs.F90
@@ -19,6 +19,8 @@ module GFS_typedefs
        use h2o_def,                  only: levh2o,      h2o_coeff
        use aerclm_def,               only: ntrcaer,     ntrcaerm
 #endif
+       use mpp_mod,                  only: mpp_error, FATAL
+
 
        implicit none
 
@@ -3704,6 +3706,10 @@ module GFS_typedefs
         n = get_tracer_index(Model%tracer_names, 'msa', Model%me, Model%master, Model%debug) - Model%ntchs + 1
         if (n > 0) Model%ntdiag(n) = .false.
       endif
+    endif
+
+    if (Model%satmedmf .and. Model%ntke .lt. 0) then
+      call mpp_error(FATAL, 'GFS_typedefs:: An sgs_tke tracer must be defined in the field_table if gfs_physics_nml.satmedmf is true.')
     endif
 
     ! -- setup aerosol scavenging factors

--- a/FV3/gfsphysics/GFS_layer/GFS_typedefs.F90
+++ b/FV3/gfsphysics/GFS_layer/GFS_typedefs.F90
@@ -3709,7 +3709,7 @@ module GFS_typedefs
     endif
 
     if (Model%satmedmf .and. Model%ntke .lt. 0) then
-      call mpp_error(FATAL, 'GFS_typedefs:: An sgs_tke tracer must be defined in the field_table if gfs_physics_nml.satmedmf is true.')
+      call mpp_error(FATAL, 'GFS_typedefs::control_initialize An sgs_tke tracer must be defined in the field_table if gfs_physics_nml.satmedmf is true.')
     endif
 
     ! -- setup aerosol scavenging factors


### PR DESCRIPTION
The termination of the model now looks like the following if an "sgs_tke" tracer is not defined in the `field_table` of a simulation set to use the TKE-EDMF turbulence scheme.  Previously the model would uninformatively crash with a segmentation fault.

```
FATAL from PE     2: GFS_typedefs::control_initialize An sgs_tke tracer must be defined in the field_table if gfs_physics_nml.satmedmf is true.

===================================================================================
=   BAD TERMINATION OF ONE OF YOUR APPLICATION PROCESSES
=   PID 9 RUNNING AT 25332af98bdf
=   EXIT CODE: 1
=   CLEANING UP REMAINING PROCESSES
=   YOU CAN IGNORE THE BELOW CLEANUP MESSAGES
===================================================================================
```