### PR TITLE
Raise error for misconfigured 3D physics diagnostics

### DIFF
--- a/FV3/atmos_model.F90
+++ b/FV3/atmos_model.F90
@@ -708,7 +708,7 @@ subroutine atmos_model_init (Atmos, Time_init, Time, Time_step)
    call FV3GFS_diag_register (IPD_Diag, Time, Atm_block, IPD_Control, Atmos%lon, Atmos%lat, Atmos%axes)
    if (Atm(mytile)%coarse_graining%write_coarse_diagnostics) then
       call atmosphere_coarse_diag_axes(coarse_diagnostic_axes)
-      call FV3GFS_diag_register_coarse(IPD_Diag, Time, coarse_diagnostic_axes, IPD_Diag_coarse)
+      call FV3GFS_diag_register_coarse(IPD_Diag, Time, coarse_diagnostic_axes, IPD_Control%ldiag3d, IPD_Diag_coarse)
    endif
    call IPD_initialize_rst (IPD_Control, IPD_Data, IPD_Diag, IPD_Restart, Init_parm)
 #ifdef CCPP
@@ -944,8 +944,7 @@ subroutine update_atmos_model_state (Atmos)
                             IPD_Control%fhswr, IPD_Control%fhlwr, &
                             Atm(mytile)%coarse_graining%write_coarse_diagnostics, &
                             IPD_Diag_coarse, &
-                            Atm(mytile)%delp(is:ie,js:je,:), Atmos%coarsening_strategy, Atm(mytile)%ptop, &
-                            IPD_Control%ldiag3d)
+                            Atm(mytile)%delp(is:ie,js:je,:), Atmos%coarsening_strategy, Atm(mytile)%ptop)
       if (nint(IPD_Control%fhzero) > 0) then 
         if (mod(isec,3600*nint(IPD_Control%fhzero)) == 0) diag_time = Atmos%Time
       else

--- a/FV3/atmos_model.F90
+++ b/FV3/atmos_model.F90
@@ -944,7 +944,8 @@ subroutine update_atmos_model_state (Atmos)
                             IPD_Control%fhswr, IPD_Control%fhlwr, &
                             Atm(mytile)%coarse_graining%write_coarse_diagnostics, &
                             IPD_Diag_coarse, &
-                            Atm(mytile)%delp(is:ie,js:je,:), Atmos%coarsening_strategy, Atm(mytile)%ptop)
+                            Atm(mytile)%delp(is:ie,js:je,:), Atmos%coarsening_strategy, Atm(mytile)%ptop, &
+                            IPD_Control%ldiag3d)
       if (nint(IPD_Control%fhzero) > 0) then 
         if (mod(isec,3600*nint(IPD_Control%fhzero)) == 0) diag_time = Atmos%Time
       else

--- a/FV3/io/FV3GFS_io.F90
+++ b/FV3/io/FV3GFS_io.F90
@@ -2943,7 +2943,7 @@ module FV3GFS_io_mod
   subroutine fv3gfs_diag_output(time, diag, atm_block, IPD_Data, nx, ny, levs, ntcw, ntoz, &
                                 dt, time_int, time_intfull, time_radsw, &
                                 time_radlw, write_coarse_diagnostics,&
-                                diag_coarse, delp, coarsening_strategy, ptop)
+                                diag_coarse, delp, coarsening_strategy, ptop, ldiag3d)
 !--- subroutine interface variable definitions
     type(time_type),           intent(in) :: time
     type(IPD_diag_type),       intent(in) :: diag(:)
@@ -2960,6 +2960,7 @@ module FV3GFS_io_mod
     real(kind=kind_phys),      intent(in) :: delp(isco:ieco,jsco:jeco,1:levo)
     character(len=64),         intent(in) :: coarsening_strategy
     real,                      intent(in) :: ptop
+    logical,                   intent(in) :: ldiag3d
 !--- local variables
     integer :: i, j, k, idx, nblks, nb, ix, ii, jj
     integer :: is_in, js_in, isc, jsc
@@ -3142,6 +3143,9 @@ module FV3GFS_io_mod
             !---
             !--- skipping other 3D variables with the following else statement
             !---
+            if (.not. ldiag3d) then
+              call mpp_error(FATAL, 'FV3GFS_io:: Outputting 3D diagnostics from the physics requires gfs_physics_nml.ldiag3d be set to true.')
+            endif
             if (trim(Diag(idx)%name) .eq. 'delp_phys') then
                if (Diag(idx)%id > 0) then
                   call store_data3D(Diag(idx)%id, delp, Time, idx, Diag(idx)%intpl_method, Diag(idx)%name)


### PR DESCRIPTION
This is now the output upon model termination if this occurs.  As in #132, the previous termination would be an uninformative segmentation fault.

```
FATAL from PE     0: FV3GFS_io::fv3gfs_diag_register Outputting 3D diagnostics from the physics requires gfs_physics_nml.ldiag3d be set to true.


FATAL from PE     1: FV3GFS_io::fv3gfs_diag_register Outputting 3D diagnostics from the physics requires gfs_physics_nml.ldiag3d be set to true.


FATAL from PE     0: FV3GFS_io::fv3gfs_diag_register Outputting 3D diagnostics from the physics requires gfs_physics_nml.ldiag3d be set to true.

application called MPI_Abort(MPI_COMM_WORLD, 1) - process 0
application called MPI_Abort(MPI_COMM_WORLD, 1) - process 1

===================================================================================
=   BAD TERMINATION OF ONE OF YOUR APPLICATION PROCESSES
=   PID 13 RUNNING AT 8fdbee4d008c
=   EXIT CODE: 1
=   CLEANING UP REMAINING PROCESSES
=   YOU CAN IGNORE THE BELOW CLEANUP MESSAGES
===================================================================================
```