### PR TITLE
Activate GT4PY_DEV for Daint executables and re-disable fill_dp

### DIFF
--- a/.jenkins/actions/build_bare_metal.sh
+++ b/.jenkins/actions/build_bare_metal.sh
@@ -13,6 +13,7 @@ set -o pipefail
 
 # the following environment variables need to be set
 #   CONFIGURATION_LIST - Space-separated list of configurations to test executables with
+#                        (yml file must reside in /tests/serialized_test_data_generation/configs)
 #   EXECUTABLE_SUFFIX  - Suffix to add to executable name when copied to /project
 #   EXECUTABLE_NAME    - Name of executable to use for tests
 

--- a/.jenkins/actions/build_bare_metal.sh
+++ b/.jenkins/actions/build_bare_metal.sh
@@ -104,7 +104,7 @@ echo "==== module list ===="
 module list
 echo "====================="
 
-./compile
+./compile GT4PY_DEV=Y
 
 num_exe=`/bin/ls -1d *.exe | wc -l`
 if [ "$num_exe" -lt 1 ] ; then

--- a/.jenkins/actions/build_bare_metal.sh
+++ b/.jenkins/actions/build_bare_metal.sh
@@ -1,8 +1,20 @@
 #!/bin/bash
 
-# stop on all errors (also on commands with a pipe-redirection)
+# This script provides a Jenkins action to build bare metal executables
+# on the Piz Daint system at CSCS. Several environment variables (see below)
+# are expected to be set upon execution.
+# If the build runs through successfully, the resulting executables are stored.
+
+# 2021/01/22 Oliver Fuhrer, Vulcan Inc, oliverf@vulcan.com
+
+# stop on all errors (also on errors in a pipe-redirection)
 set -e
 set -o pipefail
+
+# the following environment variables need to be set
+#   CONFIGURATION_LIST - Space-separated list of configurations to test executables with
+#   EXECUTABLE_SUFFIX  - Suffix to add to executable name when copied to /project
+#   EXECUTABLE_NAME    - Name of executable to use for tests
 
 INSTALL_DIR=${PROJECT}/../install
 FV3GFSEXE_DIR=${INSTALL_DIR}/fv3gfs-fortran/
@@ -116,7 +128,7 @@ cd -
 # note: we setup the rundir using fv3config in a separate script in order to keep
 #       the environment of this script clean (no modules loaded etc.)
 echo "### run install and example"
-for config in c12_6ranks_standard c48_6ranks_standard ; do
+for config in ${CONFIGURATION_LIST} ; do
 
     script=/tmp/create_rundir_$$.sh
     configdir=${rootdir}/tests/serialized_test_data_generation/configs
@@ -151,7 +163,7 @@ EOF1
     sed -i 's|set -x||g' ${jobfile}
     sed -i 's|<OUTFILE>|'"${jobfile}.out"'|g' ${jobfile}
     sed -i 's|<G2G>|'"source ./module.env; module list"'|g' ${jobfile}
-    sed -i 's|<CMD>|'"srun -n 6 ./fv3_64bit.exe"'|g' ${jobfile}
+    sed -i 's|<CMD>|'"srun -n 6 ./${EXECUTABLE_NAME}"'|g' ${jobfile}
     sed -i 's|<NAME>|'"fv3_test"'|g' ${jobfile}
     sed -i 's|<NTASKS>|12|g' ${jobfile}
     sed -i 's|<NTASKSPERNODE>|'"12"'|g' ${jobfile}
@@ -173,7 +185,10 @@ done
 # copy executables to install dir (and add meta-information)
 echo "### saving executables"
 mkdir -p ${INSTALL_DIR}/fv3gfs-fortran/${compiler}
-cp ${rootdir}/FV3/*.exe ${INSTALL_DIR}/fv3gfs-fortran/${compiler}/
+for f in ${rootdir}/FV3/*.exe ; do
+    exe_name=`basename ${f} | sed 's/\.exe$//g'`
+    cp ${f} ${INSTALL_DIR}/fv3gfs-fortran/${compiler}/${exe_name}${EXECUTABLE_SUFFIX}.exe
+done
 cp ${rootdir}/FV3/conf/modules.fv3 ${INSTALL_DIR}/fv3gfs-fortran/${compiler}/module.env
 cat > ${INSTALL_DIR}/fv3gfs-fortran/${compiler}/git.env <<EOF2
 GIT_URL = ${GIT_URL}

--- a/tests/serialized_test_data_generation/Makefile
+++ b/tests/serialized_test_data_generation/Makefile
@@ -10,7 +10,7 @@ SER_ENV ?= ALL
 # -convention: <tag>-<some large conceptual version change>.<serialization statement change>.<hotfix>
 # -version number should be increased when serialization data is expected to change
 # -omit tag (e.g. 7.1.1) for "operational" serialization data, use tag for experimental serialization data
-FORTRAN_VERSION ?= 7.2.3
+FORTRAN_VERSION ?= 7.2.5
 # docker container image setup (used for running model, see ../../README.md)
 GCR_URL = us.gcr.io/vcm-ml
 COMPILED_IMAGE = $(GCR_URL)/fv3gfs-compiled:$(FORTRAN_VERSION)-serialize-gt4pydev

--- a/tests/serialized_test_data_generation/configs/c12_54ranks_standard.yml
+++ b/tests/serialized_test_data_generation/configs/c12_54ranks_standard.yml
@@ -120,7 +120,7 @@ namelist:
     dwind_2d: false
     external_ic: true
     fill: true
-    fill_dp: true
+    fill_dp: false
     fv_debug: false
     fv_sg_adj: 600
     gfs_phil: false

--- a/tests/serialized_test_data_generation/configs/c12_6ranks_standard.yml
+++ b/tests/serialized_test_data_generation/configs/c12_6ranks_standard.yml
@@ -120,7 +120,7 @@ namelist:
     dwind_2d: false
     external_ic: true
     fill: true
-    fill_dp: true
+    fill_dp: false
     fv_debug: false
     fv_sg_adj: 600
     gfs_phil: false

--- a/tests/serialized_test_data_generation/configs/c48_6ranks_standard.yml
+++ b/tests/serialized_test_data_generation/configs/c48_6ranks_standard.yml
@@ -120,7 +120,7 @@ namelist:
     dwind_2d: false
     external_ic: true
     fill: true
-    fill_dp: true
+    fill_dp: false
     fv_debug: false
     fv_sg_adj: 600
     gfs_phil: false


### PR DESCRIPTION
This PR does three things:
1) Activates the GT4PY_DEV compile time flag in order to do an apples to apples comparison of what is being executed in Python and Fortran.
2) Switches off `fill_dp` again in the remaining namelists since it turns out that this seems to work on Piz Daint. Increase serialized data version number to 7.2.5 in order to have a clean slate and solve the "failing because of `input.nml` error".
3) Improves the Jenkins action to build bare metal executables on Piz Daint to be more parameterizable.

Since we don't have a PR builder for this on Jenkins, I've pointed the fv3gfs-fortran-build-bare-metal plan to this branch and given it a spin. Everything runs successfully: https://jenkins.ginko.ch/job/fv3gfs-fortran-build-bare-metal/56/