### PR TITLE
Refactor diag_manager-controlled diagnostics for backwards compatibility

### DIFF
--- a/FV3/atmos_model.F90
+++ b/FV3/atmos_model.F90
@@ -105,8 +105,8 @@ use IPD_driver,         only: IPD_initialize, IPD_initialize_rst
 use CCPP_driver,        only: CCPP_step, non_uniform_blocks
 #else
 use IPD_driver,         only: IPD_initialize, IPD_initialize_rst, IPD_step
-use physics_abstraction_layer, only: time_vary_step, radiation_step1, physics_step1, physics_step2, &
-                                     populate_diag_manager_controlled_diagnostics
+use physics_abstraction_layer, only: time_vary_step, radiation_step1, physics_step1, physics_step2
+
 #endif
 
 use stochastic_physics, only: init_stochastic_physics,         &
@@ -117,7 +117,7 @@ use FV3GFS_io_mod,      only: FV3GFS_restart_read, FV3GFS_restart_write, &
                               FV3GFS_IPD_checksum,                       &
                               FV3GFS_diag_register, FV3GFS_diag_output,  &
                               DIAG_SIZE, FV3GFS_restart_write_coarse,    &
-                              FV3GFS_diag_register_coarse, register_diag_manager_controlled_diagnostics, &
+                              FV3GFS_diag_register_coarse, &
                               send_diag_manager_controlled_diagnostic_data
 use fv_iau_mod,         only: iau_external_data_type,getiauforcing,iau_initialize
 use module_fv3_config,  only: output_1st_tstep_rst, first_kdt, nsout
@@ -207,15 +207,11 @@ type(IPD_control_type)              :: IPD_Control
 type(IPD_data_type),    allocatable :: IPD_Data(:)  ! number of blocks
 type(IPD_diag_type),    target      :: IPD_Diag(DIAG_SIZE)
 type(IPD_diag_type),    target      :: IPD_Diag_coarse(DIAG_SIZE)
-type(IPD_diag_type),    target      :: IPD_Diag_diag_manager_controlled(DIAG_SIZE)
-type(IPD_diag_type),    target      :: IPD_Diag_diag_manager_controlled_coarse(DIAG_SIZE)
 type(IPD_restart_type)              :: IPD_Restart
 #else
 ! IPD_Control and IPD_Data are coming from CCPP_data
 type(IPD_diag_type),    target      :: IPD_Diag(DIAG_SIZE)
 type(IPD_diag_type),    target      :: IPD_Diag_coarse(DIAG_SIZE)
-type(IPD_diag_type),    target      :: IPD_Diag_diag_manager_controlled(DIAG_SIZE)
-type(IPD_diag_type),    target      :: IPD_Diag_diag_manager_controlled_coarse(DIAG_SIZE)
 type(IPD_restart_type)              :: IPD_Restart
 #endif
 
@@ -652,8 +648,6 @@ subroutine atmos_model_init (Atmos, Time_init, Time, Time_step)
    call IPD_initialize (IPD_Control, IPD_Data, IPD_Diag, IPD_Restart, Init_parm)
 #endif
 
-   call populate_diag_manager_controlled_diagnostics(IPD_Diag_diag_manager_controlled, IPD_Data%IntDiag, size(IPD_Data%Statein))
-
    if (IPD_Control%do_sppt .OR. IPD_Control%do_shum .OR. IPD_Control%do_skeb .OR. IPD_Control%do_sfcperts) then
       ! Initialize stochastic physics
       call init_stochastic_physics(IPD_Control, Init_parm, mpp_npes(), nthrds)
@@ -714,11 +708,9 @@ subroutine atmos_model_init (Atmos, Time_init, Time, Time_step)
 
    call atmosphere_nggps_diag (Time, init=.true.)
    call FV3GFS_diag_register (IPD_Diag, Time, Atm_block, IPD_Control, Atmos%lon, Atmos%lat, Atmos%axes)
-   call register_diag_manager_controlled_diagnostics(IPD_Diag_diag_manager_controlled, Time, Atmos%axes)
    if (Atm(mytile)%coarse_graining%write_coarse_diagnostics) then
       call atmosphere_coarse_diag_axes(coarse_diagnostic_axes)
       call FV3GFS_diag_register_coarse(IPD_Diag, Time, coarse_diagnostic_axes, IPD_Control%ldiag3d, IPD_Diag_coarse)
-      call FV3GFS_diag_register_coarse(IPD_Diag_diag_manager_controlled, Time, coarse_diagnostic_axes, IPD_Control%ldiag3d, IPD_Diag_diag_manager_controlled_coarse)
    endif
    call IPD_initialize_rst (IPD_Control, IPD_Data, IPD_Diag, IPD_Restart, Init_parm)
 #ifdef CCPP
@@ -929,10 +921,10 @@ subroutine update_atmos_model_state (Atmos)
     call get_time (Atmos%Time - Atmos%Time_init, seconds)
     call atmosphere_nggps_diag(Atmos%Time,ltavg=.true.,avg_max_length=avg_max_length)
     call get_fine_array_bounds(is, ie, js, je)
-    call send_diag_manager_controlled_diagnostic_data(Atmos%Time, IPD_Diag_diag_manager_controlled, &
+    call send_diag_manager_controlled_diagnostic_data(Atmos%Time, IPD_Diag, &
       Atm_block, IPD_Data, IPD_Control%nx, IPD_Control%ny, IPD_Control%levs, &
       Atm(mytile)%coarse_graining%write_coarse_diagnostics, &
-      IPD_Diag_diag_manager_controlled_coarse, Atm(mytile)%delp(is:ie,js:je,:), &
+      IPD_Diag_coarse, Atm(mytile)%delp(is:ie,js:je,:), &
       Atmos%coarsening_strategy, Atm(mytile)%ptop)
     if (ANY(nint(fdiag(:)*3600.0) == seconds) .or. (IPD_Control%kdt == first_kdt) .or. nsout > 0) then
       if (mpp_pe() == mpp_root_pe()) write(6,*) "---isec,seconds",isec,seconds

--- a/FV3/gfsphysics/GFS_layer/GFS_abstraction_layer.F90
+++ b/FV3/gfsphysics/GFS_layer/GFS_abstraction_layer.F90
@@ -22,8 +22,7 @@ module physics_abstraction_layer
                              restart_populate =>  GFS_restart_populate
 
   use GFS_diagnostics, only: diagnostic_type      =>  GFS_externaldiag_type,    &
-                             diagnostic_populate  =>  GFS_externaldiag_populate, &
-                             populate_diag_manager_controlled_diagnostics => GFS_populate_diag_manager_controlled_diagnostics
+                             diagnostic_populate  =>  GFS_externaldiag_populate
 
 #ifdef CCPP
   use GFS_driver,      only: initialize       =>  GFS_initialize

--- a/FV3/gfsphysics/GFS_layer/GFS_diagnostics.F90
+++ b/FV3/gfsphysics/GFS_layer/GFS_diagnostics.F90
@@ -3268,7 +3268,7 @@ module GFS_diagnostics
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'ifd'
-    ExtDiag(idx)%desc = 'nsst idx to start dtlm run or not'
+    ExtDiag(idx)%desc = 'nsst index to start dtlm run or not'
     ExtDiag(idx)%unit = 'n/a'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
     allocate (ExtDiag(idx)%data(nblks))

--- a/FV3/gfsphysics/GFS_layer/GFS_diagnostics.F90
+++ b/FV3/gfsphysics/GFS_layer/GFS_diagnostics.F90
@@ -38,6 +38,7 @@ module GFS_diagnostics
     character(len=64)    :: mask
     character(len=64)    :: intpl_method
     character(len=64)    :: coarse_graining_method = 'unspecified'
+    logical :: diag_manager_controlled = .false.
     real(kind=kind_phys) :: cnvfac
     type(data_subtype), dimension(:), allocatable :: data
    end type GFS_externaldiag_type
@@ -46,358 +47,11 @@ module GFS_diagnostics
   public  GFS_externaldiag_type
 
   !--- public interfaces ---
-  public  GFS_externaldiag_populate, GFS_populate_diag_manager_controlled_diagnostics
+  public  GFS_externaldiag_populate
  
   CONTAINS
 
 !%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-
-subroutine GFS_populate_diag_manager_controlled_diagnostics(Diag, IntDiag, nblks)
-  type(GFS_externaldiag_type), intent(inout) :: Diag(:)
-  type(GFS_diag_type), intent(in) :: IntDiag(:)
-  integer, intent(in) :: nblks
-
-  integer :: nb
-  integer :: index = 1
-  
-  Diag(index)%axes = 3
-  Diag(index)%name = 'tendency_of_air_temperature_due_to_longwave_heating'
-  Diag(index)%desc = 'temperature tendency due to longwave radiation'
-  Diag(index)%unit = 'K/s'
-  Diag(index)%mod_name = 'gfs_phys'
-  Diag(index)%coarse_graining_method = 'mass_weighted'
-  allocate (Diag(index)%data(nblks))
-  do nb = 1,nblks
-    Diag(index)%data(nb)%var3 => IntDiag(nb)%t_dt(:,:,1)
-  enddo
-
-  index = index + 1
-  Diag(index)%axes = 3
-  Diag(index)%name = 'tendency_of_air_temperature_due_to_shortwave_heating'
-  Diag(index)%desc = 'temperature tendency due to shortwave radiation'
-  Diag(index)%unit = 'K/s'
-  Diag(index)%mod_name = 'gfs_phys'
-  Diag(index)%coarse_graining_method = 'mass_weighted'
-  allocate (Diag(index)%data(nblks))
-  do nb = 1,nblks
-    Diag(index)%data(nb)%var3 => IntDiag(nb)%t_dt(:,:,2)
-  enddo
-
-  index = index + 1
-  Diag(index)%axes = 3
-  Diag(index)%name = 'tendency_of_air_temperature_due_to_turbulence'
-  Diag(index)%desc = 'temperature tendency due to turbulence scheme'
-  Diag(index)%unit = 'K/s'
-  Diag(index)%mod_name = 'gfs_phys'
-  Diag(index)%coarse_graining_method = 'mass_weighted'
-  allocate (Diag(index)%data(nblks))
-  do nb = 1,nblks
-    Diag(index)%data(nb)%var3 => IntDiag(nb)%t_dt(:,:,3)
-  enddo
-
-  index = index + 1
-  Diag(index)%axes = 3
-  Diag(index)%name = 'tendency_of_air_temperature_due_to_deep_convection'
-  Diag(index)%desc = 'temperature tendency due to deep convection'
-  Diag(index)%unit = 'K/s'
-  Diag(index)%mod_name = 'gfs_phys'
-  Diag(index)%coarse_graining_method = 'mass_weighted'
-  allocate (Diag(index)%data(nblks))
-  do nb = 1,nblks
-    Diag(index)%data(nb)%var3 => IntDiag(nb)%t_dt(:,:,4)
-  enddo
-
-  index = index + 1
-  Diag(index)%axes = 3
-  Diag(index)%name = 'tendency_of_air_temperature_due_to_shallow_convection'
-  Diag(index)%desc = 'temperature tendency due to shallow convection'
-  Diag(index)%unit = 'K/s'
-  Diag(index)%mod_name = 'gfs_phys'
-  Diag(index)%coarse_graining_method = 'mass_weighted'
-  allocate (Diag(index)%data(nblks))
-  do nb = 1,nblks
-    Diag(index)%data(nb)%var3 => IntDiag(nb)%t_dt(:,:,5)
-  enddo
-
-  index = index + 1
-  Diag(index)%axes = 3
-  Diag(index)%name = 'tendency_of_air_temperature_due_to_microphysics'
-  Diag(index)%desc = 'temperature tendency due to micro-physics'
-  Diag(index)%unit = 'K/s'
-  Diag(index)%mod_name = 'gfs_phys'
-  Diag(index)%coarse_graining_method = 'mass_weighted'
-  allocate (Diag(index)%data(nblks))
-  do nb = 1,nblks
-    Diag(index)%data(nb)%var3 => IntDiag(nb)%t_dt(:,:,6)
-  enddo
-
-  index = index + 1
-  Diag(index)%axes = 3
-  Diag(index)%name = 'tendency_of_air_temperature_due_to_dissipation_of_gravity_waves'
-  Diag(index)%desc = 'temperature tendency due to gravity wave drag'
-  Diag(index)%unit = 'K/s'
-  Diag(index)%mod_name = 'gfs_phys'
-  Diag(index)%coarse_graining_method = 'mass_weighted'
-  allocate (Diag(index)%data(nblks))
-  do nb = 1,nblks
-    Diag(index)%data(nb)%var3 => IntDiag(nb)%t_dt(:,:,7)
-  enddo
-
-  index = index + 1
-  Diag(index)%axes = 3
-  Diag(index)%name = 'tendency_of_air_temperature_due_to_longwave_heating_assuming_clear_sky'
-  Diag(index)%desc = 'temperature tendency due to clear sky longwave radiation'
-  Diag(index)%unit = 'K/s'
-  Diag(index)%mod_name = 'gfs_phys'
-  Diag(index)%coarse_graining_method = 'mass_weighted'
-  allocate (Diag(index)%data(nblks))
-  do nb = 1,nblks
-    Diag(index)%data(nb)%var3 => IntDiag(nb)%t_dt(:,:,8)
-  enddo
-
-  index = index + 1
-  Diag(index)%axes = 3
-  Diag(index)%name = 'tendency_of_air_temperature_due_to_shortwave_heating_assuming_clear_sky'
-  Diag(index)%desc = 'temperature tendency due to clear sky shortwave radiation'
-  Diag(index)%unit = 'K/s'
-  Diag(index)%mod_name = 'gfs_phys'
-  Diag(index)%coarse_graining_method = 'mass_weighted'
-  allocate (Diag(index)%data(nblks))
-  do nb = 1,nblks
-    Diag(index)%data(nb)%var3 => IntDiag(nb)%t_dt(:,:,9)
-  enddo
-
-! Vertically integrated instantaneous temperature tendency diagnostics
-  index = index + 1
-  Diag(index)%axes = 2
-  Diag(index)%name = 'vertically_integrated_tendency_of_air_temperature_due_to_longwave_heating'
-  Diag(index)%desc = 'vertically integrated temperature tendency due to longwave radiation'
-  Diag(index)%unit = 'W/m**2'
-  Diag(index)%mod_name = 'gfs_phys'
-  Diag(index)%coarse_graining_method = 'area_weighted'
-  allocate (Diag(index)%data(nblks))
-  do nb = 1,nblks
-    Diag(index)%data(nb)%var2 => IntDiag(nb)%t_dt_int(:,1)
-  enddo
-
-  index = index + 1
-  Diag(index)%axes = 2
-  Diag(index)%name = 'vertically_integrated_tendency_of_air_temperature_due_to_shortwave_heating'
-  Diag(index)%desc = 'vertically integrated temperature tendency due to shortwave radiation'
-  Diag(index)%unit = 'W/m**2'
-  Diag(index)%mod_name = 'gfs_phys'
-  Diag(index)%coarse_graining_method = 'area_weighted'
-  allocate (Diag(index)%data(nblks))
-  do nb = 1,nblks
-    Diag(index)%data(nb)%var2 => IntDiag(nb)%t_dt_int(:,2)
-  enddo
-
-  index = index + 1
-  Diag(index)%axes = 2
-  Diag(index)%name = 'vertically_integrated_tendency_of_air_temperature_due_to_turbulence'
-  Diag(index)%desc = 'vertically integrated temperature tendency due to turbulence scheme'
-  Diag(index)%unit = 'W/m**2'
-  Diag(index)%mod_name = 'gfs_phys'
-  Diag(index)%coarse_graining_method = 'area_weighted'
-  allocate (Diag(index)%data(nblks))
-  do nb = 1,nblks
-    Diag(index)%data(nb)%var2 => IntDiag(nb)%t_dt_int(:,3)
-  enddo
-
-  index = index + 1
-  Diag(index)%axes = 2
-  Diag(index)%name = 'vertically_integrated_tendency_of_air_temperature_due_to_deep_convection'
-  Diag(index)%desc = 'vertically integrated temperature tendency due to deep convection'
-  Diag(index)%unit = 'W/m**2'
-  Diag(index)%mod_name = 'gfs_phys'
-  Diag(index)%coarse_graining_method = 'area_weighted'
-  allocate (Diag(index)%data(nblks))
-  do nb = 1,nblks
-    Diag(index)%data(nb)%var2 => IntDiag(nb)%t_dt_int(:,4)
-  enddo
-
-  index = index + 1
-  Diag(index)%axes = 2
-  Diag(index)%name = 'vertically_integrated_tendency_of_air_temperature_due_to_shallow_convection'
-  Diag(index)%desc = 'vertically integrated temperature tendency due to shallow convection'
-  Diag(index)%unit = 'W/m**2'
-  Diag(index)%mod_name = 'gfs_phys'
-  Diag(index)%coarse_graining_method = 'area_weighted'
-  allocate (Diag(index)%data(nblks))
-  do nb = 1,nblks
-    Diag(index)%data(nb)%var2 => IntDiag(nb)%t_dt_int(:,5)
-  enddo
-
-  index = index + 1
-  Diag(index)%axes = 2
-  Diag(index)%name = 'vertically_integrated_tendency_of_air_temperature_due_to_microphysics'
-  Diag(index)%desc = 'vertically integrated temperature tendency due to micro-physics'
-  Diag(index)%unit = 'W/m**2'
-  Diag(index)%mod_name = 'gfs_phys'
-  Diag(index)%coarse_graining_method = 'area_weighted'
-  allocate (Diag(index)%data(nblks))
-  do nb = 1,nblks
-    Diag(index)%data(nb)%var2 => IntDiag(nb)%t_dt_int(:,6)
-  enddo
-
-  index = index + 1
-  Diag(index)%axes = 2
-  Diag(index)%name = 'vertically_integrated_tendency_of_air_temperature_due_to_dissipation_of_gravity_waves'
-  Diag(index)%desc = 'vertically integrated temperature tendency due to gravity wave drag'
-  Diag(index)%unit = 'W/m**2'
-  Diag(index)%mod_name = 'gfs_phys'
-  Diag(index)%coarse_graining_method = 'area_weighted'
-  allocate (Diag(index)%data(nblks))
-  do nb = 1,nblks
-    Diag(index)%data(nb)%var2 => IntDiag(nb)%t_dt_int(:,7)
-  enddo
-
-  index = index + 1
-  Diag(index)%axes = 2
-  Diag(index)%name = 'vertically_integrated_tendency_of_air_temperature_due_to_longwave_heating_assuming_clear_sky'
-  Diag(index)%desc = 'vertically integrated temperature tendency due to clear sky longwave radiation'
-  Diag(index)%unit = 'W/m**2'
-  Diag(index)%mod_name = 'gfs_phys'
-  Diag(index)%coarse_graining_method = 'area_weighted'
-  allocate (Diag(index)%data(nblks))
-  do nb = 1,nblks
-    Diag(index)%data(nb)%var2 => IntDiag(nb)%t_dt_int(:,8)
-  enddo
-
-  index = index + 1
-  Diag(index)%axes = 2
-  Diag(index)%name = 'vertically_integrated_tendency_of_air_temperature_due_to_shortwave_heating_assuming_clear_sky'
-  Diag(index)%desc = 'vertically integrated temperature tendency due to clear sky shortwave radiation'
-  Diag(index)%unit = 'W/m**2'
-  Diag(index)%mod_name = 'gfs_phys'
-  Diag(index)%coarse_graining_method = 'area_weighted'
-  allocate (Diag(index)%data(nblks))
-  do nb = 1,nblks
-    Diag(index)%data(nb)%var2 => IntDiag(nb)%t_dt_int(:,9)
-  enddo
-
-  index = index + 1
-  Diag(index)%axes = 3
-  Diag(index)%name = 'tendency_of_specific_humidity_due_to_turbulence'
-  Diag(index)%desc = 'water vapor tendency due to turbulence scheme'
-  Diag(index)%unit = 'kg/kg/s'
-  Diag(index)%mod_name = 'gfs_phys'
-  Diag(index)%coarse_graining_method = 'mass_weighted'
-  allocate (Diag(index)%data(nblks))
-  do nb = 1,nblks
-    Diag(index)%data(nb)%var3 => IntDiag(nb)%q_dt(:,:,1)
-  enddo
-
-  index = index + 1
-  Diag(index)%axes = 3
-  Diag(index)%name = 'tendency_of_specific_humidity_due_to_deep_convection'
-  Diag(index)%desc = 'water vapor tendency due to deep convection'
-  Diag(index)%unit = 'kg/kg/s'
-  Diag(index)%mod_name = 'gfs_phys'
-  Diag(index)%coarse_graining_method = 'mass_weighted'
-  allocate (Diag(index)%data(nblks))
-  do nb = 1,nblks
-    Diag(index)%data(nb)%var3 => IntDiag(nb)%q_dt(:,:,2)
-  enddo
-
-  index = index + 1
-  Diag(index)%axes = 3
-  Diag(index)%name = 'tendency_of_specific_humidity_due_to_shallow_convection'
-  Diag(index)%desc = 'water vapor tendency due to shallow convection'
-  Diag(index)%unit = 'kg/kg/s'
-  Diag(index)%mod_name = 'gfs_phys'
-  Diag(index)%coarse_graining_method = 'mass_weighted'
-  allocate (Diag(index)%data(nblks))
-  do nb = 1,nblks
-    Diag(index)%data(nb)%var3 => IntDiag(nb)%q_dt(:,:,3)
-  enddo
-
-  index = index + 1
-  Diag(index)%axes = 3
-  Diag(index)%name = 'tendency_of_specific_humidity_due_to_microphysics'
-  Diag(index)%desc = 'water vapor tendency due to microphysics'
-  Diag(index)%unit = 'kg/kg/s'
-  Diag(index)%mod_name = 'gfs_phys'
-  Diag(index)%coarse_graining_method = 'mass_weighted'
-  allocate (Diag(index)%data(nblks))
-  do nb = 1,nblks
-    Diag(index)%data(nb)%var3 => IntDiag(nb)%q_dt(:,:,4)
-  enddo
-
-  index = index + 1
-  Diag(index)%axes = 3
-  Diag(index)%name = 'tendency_of_specific_humidity_due_to_change_in_atmosphere_mass'
-  Diag(index)%desc = 'residual water vapor tendency'
-  Diag(index)%unit = 'kg/kg/s'
-  Diag(index)%mod_name = 'gfs_phys'
-  Diag(index)%coarse_graining_method = 'mass_weighted'
-  allocate (Diag(index)%data(nblks))
-  do nb = 1,nblks
-    Diag(index)%data(nb)%var3 => IntDiag(nb)%q_dt(:,:,5)
-  enddo
-
-  ! Vertically integrated instantaneous specific humidity tendency diagnostics
-  index = index + 1
-  Diag(index)%axes = 2
-  Diag(index)%name = 'vertically_integrated_tendency_of_specific_humidity_due_to_turbulence'
-  Diag(index)%desc = 'vertically integrated water vapor tendency due to turbulence scheme'
-  Diag(index)%unit = 'kg/m**2/s'
-  Diag(index)%mod_name = 'gfs_phys'
-  Diag(index)%coarse_graining_method = 'area_weighted'
-  allocate (Diag(index)%data(nblks))
-  do nb = 1,nblks
-    Diag(index)%data(nb)%var2 => IntDiag(nb)%q_dt_int(:,1)
-  enddo
-
-  index = index + 1
-  Diag(index)%axes = 2
-  Diag(index)%name = 'vertically_integrated_tendency_of_specific_humidity_due_to_deep_convection'
-  Diag(index)%desc = 'vertically integrated water vapor tendency due to deep convection'
-  Diag(index)%unit = 'kg/m**2/s'
-  Diag(index)%mod_name = 'gfs_phys'
-  Diag(index)%coarse_graining_method = 'area_weighted'
-  allocate (Diag(index)%data(nblks))
-  do nb = 1,nblks
-    Diag(index)%data(nb)%var2 => IntDiag(nb)%q_dt_int(:,2)
-  enddo
-
-  index = index + 1
-  Diag(index)%axes = 2
-  Diag(index)%name = 'vertically_integrated_tendency_of_specific_humidity_due_to_shallow_convection'
-  Diag(index)%desc = 'vertically integrated water vapor tendency due to shallow convection'
-  Diag(index)%unit = 'kg/m**2/s'
-  Diag(index)%mod_name = 'gfs_phys'
-  Diag(index)%coarse_graining_method = 'area_weighted'
-  allocate (Diag(index)%data(nblks))
-  do nb = 1,nblks
-    Diag(index)%data(nb)%var2 => IntDiag(nb)%q_dt_int(:,3)
-  enddo
-
-  index = index + 1
-  Diag(index)%axes = 2
-  Diag(index)%name = 'vertically_integrated_tendency_of_specific_humidity_due_to_microphysics'
-  Diag(index)%desc = 'vertically integrated water vapor tendency due to microphysics'
-  Diag(index)%unit = 'kg/m**2/s'
-  Diag(index)%mod_name = 'gfs_phys'
-  Diag(index)%coarse_graining_method = 'area_weighted'
-  allocate (Diag(index)%data(nblks))
-  do nb = 1,nblks
-    Diag(index)%data(nb)%var2 => IntDiag(nb)%q_dt_int(:,4)
-  enddo
-
-  index = index + 1
-  Diag(index)%axes = 2
-  Diag(index)%name = 'vertically_integrated_tendency_of_specific_humidity_due_to_change_in_atmosphere_mass'
-  Diag(index)%desc = 'vertically integrated residual water vapor tendency'
-  Diag(index)%unit = 'kg/m**2/s'
-  Diag(index)%mod_name = 'gfs_phys'
-  Diag(index)%coarse_graining_method = 'area_weighted'
-  allocate (Diag(index)%data(nblks))
-  do nb = 1,nblks
-    Diag(index)%data(nb)%var2 => IntDiag(nb)%q_dt_int(:,5)
-  enddo
-end subroutine GFS_populate_diag_manager_controlled_diagnostics
-
 !-------------------------------------------------------------------------      
 !--- GFS_externaldiag_populate ---
 !-------------------------------------------------------------------------      
@@ -3614,7 +3268,7 @@ end subroutine GFS_populate_diag_manager_controlled_diagnostics
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'ifd'
-    ExtDiag(idx)%desc = 'nsst index to start dtlm run or not'
+    ExtDiag(idx)%desc = 'nsst idx to start dtlm run or not'
     ExtDiag(idx)%unit = 'n/a'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
     allocate (ExtDiag(idx)%data(nblks))
@@ -3645,6 +3299,372 @@ end subroutine GFS_populate_diag_manager_controlled_diagnostics
     enddo
 !--------------------------nsst variables
   endif
+
+  idx = idx + 1
+  ExtDiag(idx)%axes = 3
+  ExtDiag(idx)%name = 'tendency_of_air_temperature_due_to_longwave_heating'
+  ExtDiag(idx)%desc = 'temperature tendency due to longwave radiation'
+  ExtDiag(idx)%unit = 'K/s'
+  ExtDiag(idx)%mod_name = 'gfs_phys'
+  ExtDiag(idx)%coarse_graining_method = 'mass_weighted'
+  ExtDiag(idx)%diag_manager_controlled = .true.
+  allocate (ExtDiag(idx)%data(nblks))
+  do nb = 1,nblks
+    ExtDiag(idx)%data(nb)%var3 => IntDiag(nb)%t_dt(:,:,1)
+  enddo
+
+  idx = idx + 1
+  ExtDiag(idx)%axes = 3
+  ExtDiag(idx)%name = 'tendency_of_air_temperature_due_to_shortwave_heating'
+  ExtDiag(idx)%desc = 'temperature tendency due to shortwave radiation'
+  ExtDiag(idx)%unit = 'K/s'
+  ExtDiag(idx)%mod_name = 'gfs_phys'
+  ExtDiag(idx)%coarse_graining_method = 'mass_weighted'
+  ExtDiag(idx)%diag_manager_controlled = .true.
+  allocate (ExtDiag(idx)%data(nblks))
+  do nb = 1,nblks
+    ExtDiag(idx)%data(nb)%var3 => IntDiag(nb)%t_dt(:,:,2)
+  enddo
+
+  idx = idx + 1
+  ExtDiag(idx)%axes = 3
+  ExtDiag(idx)%name = 'tendency_of_air_temperature_due_to_turbulence'
+  ExtDiag(idx)%desc = 'temperature tendency due to turbulence scheme'
+  ExtDiag(idx)%unit = 'K/s'
+  ExtDiag(idx)%mod_name = 'gfs_phys'
+  ExtDiag(idx)%coarse_graining_method = 'mass_weighted'
+  ExtDiag(idx)%diag_manager_controlled = .true.
+  allocate (ExtDiag(idx)%data(nblks))
+  do nb = 1,nblks
+    ExtDiag(idx)%data(nb)%var3 => IntDiag(nb)%t_dt(:,:,3)
+  enddo
+
+  idx = idx + 1
+  ExtDiag(idx)%axes = 3
+  ExtDiag(idx)%name = 'tendency_of_air_temperature_due_to_deep_convection'
+  ExtDiag(idx)%desc = 'temperature tendency due to deep convection'
+  ExtDiag(idx)%unit = 'K/s'
+  ExtDiag(idx)%mod_name = 'gfs_phys'
+  ExtDiag(idx)%coarse_graining_method = 'mass_weighted'
+  ExtDiag(idx)%diag_manager_controlled = .true.
+  allocate (ExtDiag(idx)%data(nblks))
+  do nb = 1,nblks
+    ExtDiag(idx)%data(nb)%var3 => IntDiag(nb)%t_dt(:,:,4)
+  enddo
+
+  idx = idx + 1
+  ExtDiag(idx)%axes = 3
+  ExtDiag(idx)%name = 'tendency_of_air_temperature_due_to_shallow_convection'
+  ExtDiag(idx)%desc = 'temperature tendency due to shallow convection'
+  ExtDiag(idx)%unit = 'K/s'
+  ExtDiag(idx)%mod_name = 'gfs_phys'
+  ExtDiag(idx)%coarse_graining_method = 'mass_weighted'
+  ExtDiag(idx)%diag_manager_controlled = .true.
+  allocate (ExtDiag(idx)%data(nblks))
+  do nb = 1,nblks
+    ExtDiag(idx)%data(nb)%var3 => IntDiag(nb)%t_dt(:,:,5)
+  enddo
+
+  idx = idx + 1
+  ExtDiag(idx)%axes = 3
+  ExtDiag(idx)%name = 'tendency_of_air_temperature_due_to_microphysics'
+  ExtDiag(idx)%desc = 'temperature tendency due to micro-physics'
+  ExtDiag(idx)%unit = 'K/s'
+  ExtDiag(idx)%mod_name = 'gfs_phys'
+  ExtDiag(idx)%coarse_graining_method = 'mass_weighted'
+  ExtDiag(idx)%diag_manager_controlled = .true.
+  allocate (ExtDiag(idx)%data(nblks))
+  do nb = 1,nblks
+    ExtDiag(idx)%data(nb)%var3 => IntDiag(nb)%t_dt(:,:,6)
+  enddo
+
+  idx = idx + 1
+  ExtDiag(idx)%axes = 3
+  ExtDiag(idx)%name = 'tendency_of_air_temperature_due_to_dissipation_of_gravity_waves'
+  ExtDiag(idx)%desc = 'temperature tendency due to gravity wave drag'
+  ExtDiag(idx)%unit = 'K/s'
+  ExtDiag(idx)%mod_name = 'gfs_phys'
+  ExtDiag(idx)%coarse_graining_method = 'mass_weighted'
+  ExtDiag(idx)%diag_manager_controlled = .true.
+  allocate (ExtDiag(idx)%data(nblks))
+  do nb = 1,nblks
+    ExtDiag(idx)%data(nb)%var3 => IntDiag(nb)%t_dt(:,:,7)
+  enddo
+
+  idx = idx + 1
+  ExtDiag(idx)%axes = 3
+  ExtDiag(idx)%name = 'tendency_of_air_temperature_due_to_longwave_heating_assuming_clear_sky'
+  ExtDiag(idx)%desc = 'temperature tendency due to clear sky longwave radiation'
+  ExtDiag(idx)%unit = 'K/s'
+  ExtDiag(idx)%mod_name = 'gfs_phys'
+  ExtDiag(idx)%coarse_graining_method = 'mass_weighted'
+  ExtDiag(idx)%diag_manager_controlled = .true.
+  allocate (ExtDiag(idx)%data(nblks))
+  do nb = 1,nblks
+    ExtDiag(idx)%data(nb)%var3 => IntDiag(nb)%t_dt(:,:,8)
+  enddo
+
+  idx = idx + 1
+  ExtDiag(idx)%axes = 3
+  ExtDiag(idx)%name = 'tendency_of_air_temperature_due_to_shortwave_heating_assuming_clear_sky'
+  ExtDiag(idx)%desc = 'temperature tendency due to clear sky shortwave radiation'
+  ExtDiag(idx)%unit = 'K/s'
+  ExtDiag(idx)%mod_name = 'gfs_phys'
+  ExtDiag(idx)%coarse_graining_method = 'mass_weighted'
+  ExtDiag(idx)%diag_manager_controlled = .true.
+  allocate (ExtDiag(idx)%data(nblks))
+  do nb = 1,nblks
+    ExtDiag(idx)%data(nb)%var3 => IntDiag(nb)%t_dt(:,:,9)
+  enddo
+
+! Vertically integrated instantaneous temperature tendency diagnostics
+  idx = idx + 1
+  ExtDiag(idx)%axes = 2
+  ExtDiag(idx)%name = 'vertically_integrated_tendency_of_air_temperature_due_to_longwave_heating'
+  ExtDiag(idx)%desc = 'vertically integrated temperature tendency due to longwave radiation'
+  ExtDiag(idx)%unit = 'W/m**2'
+  ExtDiag(idx)%mod_name = 'gfs_phys'
+  ExtDiag(idx)%coarse_graining_method = 'area_weighted'
+  ExtDiag(idx)%diag_manager_controlled = .true.
+  allocate (ExtDiag(idx)%data(nblks))
+  do nb = 1,nblks
+    ExtDiag(idx)%data(nb)%var2 => IntDiag(nb)%t_dt_int(:,1)
+  enddo
+
+  idx = idx + 1
+  ExtDiag(idx)%axes = 2
+  ExtDiag(idx)%name = 'vertically_integrated_tendency_of_air_temperature_due_to_shortwave_heating'
+  ExtDiag(idx)%desc = 'vertically integrated temperature tendency due to shortwave radiation'
+  ExtDiag(idx)%unit = 'W/m**2'
+  ExtDiag(idx)%mod_name = 'gfs_phys'
+  ExtDiag(idx)%coarse_graining_method = 'area_weighted'
+  ExtDiag(idx)%diag_manager_controlled = .true.
+  allocate (ExtDiag(idx)%data(nblks))
+  do nb = 1,nblks
+    ExtDiag(idx)%data(nb)%var2 => IntDiag(nb)%t_dt_int(:,2)
+  enddo
+
+  idx = idx + 1
+  ExtDiag(idx)%axes = 2
+  ExtDiag(idx)%name = 'vertically_integrated_tendency_of_air_temperature_due_to_turbulence'
+  ExtDiag(idx)%desc = 'vertically integrated temperature tendency due to turbulence scheme'
+  ExtDiag(idx)%unit = 'W/m**2'
+  ExtDiag(idx)%mod_name = 'gfs_phys'
+  ExtDiag(idx)%coarse_graining_method = 'area_weighted'
+  ExtDiag(idx)%diag_manager_controlled = .true.
+  allocate (ExtDiag(idx)%data(nblks))
+  do nb = 1,nblks
+    ExtDiag(idx)%data(nb)%var2 => IntDiag(nb)%t_dt_int(:,3)
+  enddo
+
+  idx = idx + 1
+  ExtDiag(idx)%axes = 2
+  ExtDiag(idx)%name = 'vertically_integrated_tendency_of_air_temperature_due_to_deep_convection'
+  ExtDiag(idx)%desc = 'vertically integrated temperature tendency due to deep convection'
+  ExtDiag(idx)%unit = 'W/m**2'
+  ExtDiag(idx)%mod_name = 'gfs_phys'
+  ExtDiag(idx)%coarse_graining_method = 'area_weighted'
+  ExtDiag(idx)%diag_manager_controlled = .true.
+  allocate (ExtDiag(idx)%data(nblks))
+  do nb = 1,nblks
+    ExtDiag(idx)%data(nb)%var2 => IntDiag(nb)%t_dt_int(:,4)
+  enddo
+
+  idx = idx + 1
+  ExtDiag(idx)%axes = 2
+  ExtDiag(idx)%name = 'vertically_integrated_tendency_of_air_temperature_due_to_shallow_convection'
+  ExtDiag(idx)%desc = 'vertically integrated temperature tendency due to shallow convection'
+  ExtDiag(idx)%unit = 'W/m**2'
+  ExtDiag(idx)%mod_name = 'gfs_phys'
+  ExtDiag(idx)%coarse_graining_method = 'area_weighted'
+  ExtDiag(idx)%diag_manager_controlled = .true.
+  allocate (ExtDiag(idx)%data(nblks))
+  do nb = 1,nblks
+    ExtDiag(idx)%data(nb)%var2 => IntDiag(nb)%t_dt_int(:,5)
+  enddo
+
+  idx = idx + 1
+  ExtDiag(idx)%axes = 2
+  ExtDiag(idx)%name = 'vertically_integrated_tendency_of_air_temperature_due_to_microphysics'
+  ExtDiag(idx)%desc = 'vertically integrated temperature tendency due to micro-physics'
+  ExtDiag(idx)%unit = 'W/m**2'
+  ExtDiag(idx)%mod_name = 'gfs_phys'
+  ExtDiag(idx)%coarse_graining_method = 'area_weighted'
+  ExtDiag(idx)%diag_manager_controlled = .true.
+  allocate (ExtDiag(idx)%data(nblks))
+  do nb = 1,nblks
+    ExtDiag(idx)%data(nb)%var2 => IntDiag(nb)%t_dt_int(:,6)
+  enddo
+
+  idx = idx + 1
+  ExtDiag(idx)%axes = 2
+  ExtDiag(idx)%name = 'vertically_integrated_tendency_of_air_temperature_due_to_dissipation_of_gravity_waves'
+  ExtDiag(idx)%desc = 'vertically integrated temperature tendency due to gravity wave drag'
+  ExtDiag(idx)%unit = 'W/m**2'
+  ExtDiag(idx)%mod_name = 'gfs_phys'
+  ExtDiag(idx)%coarse_graining_method = 'area_weighted'
+  ExtDiag(idx)%diag_manager_controlled = .true.
+  allocate (ExtDiag(idx)%data(nblks))
+  do nb = 1,nblks
+    ExtDiag(idx)%data(nb)%var2 => IntDiag(nb)%t_dt_int(:,7)
+  enddo
+
+  idx = idx + 1
+  ExtDiag(idx)%axes = 2
+  ExtDiag(idx)%name = 'vertically_integrated_tendency_of_air_temperature_due_to_longwave_heating_assuming_clear_sky'
+  ExtDiag(idx)%desc = 'vertically integrated temperature tendency due to clear sky longwave radiation'
+  ExtDiag(idx)%unit = 'W/m**2'
+  ExtDiag(idx)%mod_name = 'gfs_phys'
+  ExtDiag(idx)%coarse_graining_method = 'area_weighted'
+  ExtDiag(idx)%diag_manager_controlled = .true.
+  allocate (ExtDiag(idx)%data(nblks))
+  do nb = 1,nblks
+    ExtDiag(idx)%data(nb)%var2 => IntDiag(nb)%t_dt_int(:,8)
+  enddo
+
+  idx = idx + 1
+  ExtDiag(idx)%axes = 2
+  ExtDiag(idx)%name = 'vertically_integrated_tendency_of_air_temperature_due_to_shortwave_heating_assuming_clear_sky'
+  ExtDiag(idx)%desc = 'vertically integrated temperature tendency due to clear sky shortwave radiation'
+  ExtDiag(idx)%unit = 'W/m**2'
+  ExtDiag(idx)%mod_name = 'gfs_phys'
+  ExtDiag(idx)%coarse_graining_method = 'area_weighted'
+  ExtDiag(idx)%diag_manager_controlled = .true.
+  allocate (ExtDiag(idx)%data(nblks))
+  do nb = 1,nblks
+    ExtDiag(idx)%data(nb)%var2 => IntDiag(nb)%t_dt_int(:,9)
+  enddo
+
+  idx = idx + 1
+  ExtDiag(idx)%axes = 3
+  ExtDiag(idx)%name = 'tendency_of_specific_humidity_due_to_turbulence'
+  ExtDiag(idx)%desc = 'water vapor tendency due to turbulence scheme'
+  ExtDiag(idx)%unit = 'kg/kg/s'
+  ExtDiag(idx)%mod_name = 'gfs_phys'
+  ExtDiag(idx)%coarse_graining_method = 'mass_weighted'
+  ExtDiag(idx)%diag_manager_controlled = .true.
+  allocate (ExtDiag(idx)%data(nblks))
+  do nb = 1,nblks
+    ExtDiag(idx)%data(nb)%var3 => IntDiag(nb)%q_dt(:,:,1)
+  enddo
+
+  idx = idx + 1
+  ExtDiag(idx)%axes = 3
+  ExtDiag(idx)%name = 'tendency_of_specific_humidity_due_to_deep_convection'
+  ExtDiag(idx)%desc = 'water vapor tendency due to deep convection'
+  ExtDiag(idx)%unit = 'kg/kg/s'
+  ExtDiag(idx)%mod_name = 'gfs_phys'
+  ExtDiag(idx)%coarse_graining_method = 'mass_weighted'
+  ExtDiag(idx)%diag_manager_controlled = .true.
+  allocate (ExtDiag(idx)%data(nblks))
+  do nb = 1,nblks
+    ExtDiag(idx)%data(nb)%var3 => IntDiag(nb)%q_dt(:,:,2)
+  enddo
+
+  idx = idx + 1
+  ExtDiag(idx)%axes = 3
+  ExtDiag(idx)%name = 'tendency_of_specific_humidity_due_to_shallow_convection'
+  ExtDiag(idx)%desc = 'water vapor tendency due to shallow convection'
+  ExtDiag(idx)%unit = 'kg/kg/s'
+  ExtDiag(idx)%mod_name = 'gfs_phys'
+  ExtDiag(idx)%coarse_graining_method = 'mass_weighted'
+  ExtDiag(idx)%diag_manager_controlled = .true.
+  allocate (ExtDiag(idx)%data(nblks))
+  do nb = 1,nblks
+    ExtDiag(idx)%data(nb)%var3 => IntDiag(nb)%q_dt(:,:,3)
+  enddo
+
+  idx = idx + 1
+  ExtDiag(idx)%axes = 3
+  ExtDiag(idx)%name = 'tendency_of_specific_humidity_due_to_microphysics'
+  ExtDiag(idx)%desc = 'water vapor tendency due to microphysics'
+  ExtDiag(idx)%unit = 'kg/kg/s'
+  ExtDiag(idx)%mod_name = 'gfs_phys'
+  ExtDiag(idx)%coarse_graining_method = 'mass_weighted'
+  ExtDiag(idx)%diag_manager_controlled = .true.
+  allocate (ExtDiag(idx)%data(nblks))
+  do nb = 1,nblks
+    ExtDiag(idx)%data(nb)%var3 => IntDiag(nb)%q_dt(:,:,4)
+  enddo
+
+  idx = idx + 1
+  ExtDiag(idx)%axes = 3
+  ExtDiag(idx)%name = 'tendency_of_specific_humidity_due_to_change_in_atmosphere_mass'
+  ExtDiag(idx)%desc = 'residual water vapor tendency'
+  ExtDiag(idx)%unit = 'kg/kg/s'
+  ExtDiag(idx)%mod_name = 'gfs_phys'
+  ExtDiag(idx)%coarse_graining_method = 'mass_weighted'
+  ExtDiag(idx)%diag_manager_controlled = .true.
+  allocate (ExtDiag(idx)%data(nblks))
+  do nb = 1,nblks
+    ExtDiag(idx)%data(nb)%var3 => IntDiag(nb)%q_dt(:,:,5)
+  enddo
+
+  ! Vertically integrated instantaneous specific humidity tendency diagnostics
+  idx = idx + 1
+  ExtDiag(idx)%axes = 2
+  ExtDiag(idx)%name = 'vertically_integrated_tendency_of_specific_humidity_due_to_turbulence'
+  ExtDiag(idx)%desc = 'vertically integrated water vapor tendency due to turbulence scheme'
+  ExtDiag(idx)%unit = 'kg/m**2/s'
+  ExtDiag(idx)%mod_name = 'gfs_phys'
+  ExtDiag(idx)%coarse_graining_method = 'area_weighted'
+  ExtDiag(idx)%diag_manager_controlled = .true.
+  allocate (ExtDiag(idx)%data(nblks))
+  do nb = 1,nblks
+    ExtDiag(idx)%data(nb)%var2 => IntDiag(nb)%q_dt_int(:,1)
+  enddo
+
+  idx = idx + 1
+  ExtDiag(idx)%axes = 2
+  ExtDiag(idx)%name = 'vertically_integrated_tendency_of_specific_humidity_due_to_deep_convection'
+  ExtDiag(idx)%desc = 'vertically integrated water vapor tendency due to deep convection'
+  ExtDiag(idx)%unit = 'kg/m**2/s'
+  ExtDiag(idx)%mod_name = 'gfs_phys'
+  ExtDiag(idx)%coarse_graining_method = 'area_weighted'
+  ExtDiag(idx)%diag_manager_controlled = .true.
+  allocate (ExtDiag(idx)%data(nblks))
+  do nb = 1,nblks
+    ExtDiag(idx)%data(nb)%var2 => IntDiag(nb)%q_dt_int(:,2)
+  enddo
+
+  idx = idx + 1
+  ExtDiag(idx)%axes = 2
+  ExtDiag(idx)%name = 'vertically_integrated_tendency_of_specific_humidity_due_to_shallow_convection'
+  ExtDiag(idx)%desc = 'vertically integrated water vapor tendency due to shallow convection'
+  ExtDiag(idx)%unit = 'kg/m**2/s'
+  ExtDiag(idx)%mod_name = 'gfs_phys'
+  ExtDiag(idx)%coarse_graining_method = 'area_weighted'
+  ExtDiag(idx)%diag_manager_controlled = .true.
+  allocate (ExtDiag(idx)%data(nblks))
+  do nb = 1,nblks
+    ExtDiag(idx)%data(nb)%var2 => IntDiag(nb)%q_dt_int(:,3)
+  enddo
+
+  idx = idx + 1
+  ExtDiag(idx)%axes = 2
+  ExtDiag(idx)%name = 'vertically_integrated_tendency_of_specific_humidity_due_to_microphysics'
+  ExtDiag(idx)%desc = 'vertically integrated water vapor tendency due to microphysics'
+  ExtDiag(idx)%unit = 'kg/m**2/s'
+  ExtDiag(idx)%mod_name = 'gfs_phys'
+  ExtDiag(idx)%coarse_graining_method = 'area_weighted'
+  ExtDiag(idx)%diag_manager_controlled = .true.
+  allocate (ExtDiag(idx)%data(nblks))
+  do nb = 1,nblks
+    ExtDiag(idx)%data(nb)%var2 => IntDiag(nb)%q_dt_int(:,4)
+  enddo
+
+  idx = idx + 1
+  ExtDiag(idx)%axes = 2
+  ExtDiag(idx)%name = 'vertically_integrated_tendency_of_specific_humidity_due_to_change_in_atmosphere_mass'
+  ExtDiag(idx)%desc = 'vertically integrated residual water vapor tendency'
+  ExtDiag(idx)%unit = 'kg/m**2/s'
+  ExtDiag(idx)%mod_name = 'gfs_phys'
+  ExtDiag(idx)%coarse_graining_method = 'area_weighted'
+  ExtDiag(idx)%diag_manager_controlled = .true.
+  allocate (ExtDiag(idx)%data(nblks))
+  do nb = 1,nblks
+    ExtDiag(idx)%data(nb)%var2 => IntDiag(nb)%q_dt_int(:,5)
+  enddo
 
 !--------------------------aerosols
 #ifdef CCPP

--- a/FV3/io/FV3GFS_io.F90
+++ b/FV3/io/FV3GFS_io.F90
@@ -3126,7 +3126,7 @@ module FV3GFS_io_mod
      
 !     if(mpp_pe()==mpp_root_pe())print *,'in,fv3gfs_io. time avg, time_int=',time_int
      do idx = 1,tot_diag_idx
-      requested = diag(idx)%id > 0 .or. diag_coarse(idx)%id > 0
+       requested = diag(idx)%id > 0 .or. diag_coarse(idx)%id > 0
        if (requested .and. .not. diag(idx)%diag_manager_controlled) then
          lcnvfac = diag(idx)%cnvfac
          if (diag(idx)%time_avg) then


### PR DESCRIPTION
This PR refactors the diagnostics-manager-controlled diagnostics introduced in #112 such that they are defined within the same data structure as the other physics diagnostics.  It does so by simply adding a flag to the derived data type (default `.false.`) denoting whether a particular diagnostic is `diag_manager_controlled` or not.  The code path taken for sending data to the diagnostics manager then depends on the value of this flag.  It should not change any answers or functionality (regression tests confirm this).

xref: https://github.com/VulcanClimateModeling/fv3gfs-wrapper/issues/230