### PR TITLE
Optimize space usage for regression data generation

### DIFF
--- a/.jenkins/actions/serialize_data.sh
+++ b/.jenkins/actions/serialize_data.sh
@@ -1,7 +1,21 @@
 #!/bin/bash -f
 
-# stop on all errors
+# This script provides an Jenkins action to run FV3GFS with serialization
+# activated in order to generate data for regression tests that are used
+# by fv3core. The data is generated and pushed to the GCP storage bucket.
+
+# 2021/01/22 Oliver Fuhrer, Vulcan Inc, oliverf@vulcan.com
+
+# stop on all errors (also on errors in a pipe-redirection)
 set -e
+set -o pipefail
+
+# the following environment variables need to be set
+#   EXPERIMENT_PATTERN - Regex pattern to select the *.yml files in the directory
+#                        /tests/serialized_test_data_generation/configs
+#   FORTRAN_VERSION    - Can be used to override the FORTRAN_VERSION number in the Makefile
+#   VALIDATE_ONLY      - Set to "true" if you only want to compare against data already on GCP
+#   FORCE_PUSH         - Set to "true" if you want to overwrite data already on GCP
 
 ##################################################
 # functions
@@ -61,26 +75,33 @@ else
     echo "FORTRAN_VERSION: (default)"
     unset FORTRAN_VERSION
 fi
+echo "VALIDATE_ONLY:   ${FORCE_PUSH}"
 echo "FORCE_PUSH:      ${FORCE_PUSH}"
-echo "=== the following setup is being used ==="
-export CUDA=y
+echo "========================================="
+
 # set up virtual env, if not already set up
 echo ">> Running pip install -r requirements.txt in venv"
 python3 -m venv venv
 . ./venv/bin/activate
 pip install --upgrade pip setuptools wheel
 pip install -r requirements.txt
+
 # configure Docker builds
+export CUDA=y
 export DOCKER_BUILDKIT=1
 export BUILD_ARGS="-q"
 export BUILD_FROM_INTERMEDIATE=y
 export BUILDKIT_PROGRESS=plain
 make pull_deps
+
 # do the work
 echo ">> Running ./make_all_datasets.sh in ./tests/serialize_test_data_generation"
 cd tests/serialized_test_data_generation
 ./make_all_datasets.sh
 cd -
+
+# deactivate virtual env
+deactivate
 
 # end timer and report time taken
 T="$(($(date +%s)-T))"

--- a/tests/serialized_test_data_generation/configs/c48_54ranks_baroclinic.yml
+++ b/tests/serialized_test_data_generation/configs/c48_54ranks_baroclinic.yml
@@ -1,0 +1,327 @@
+data_table: default
+diag_table: gs://vcm-fv3config/config/diag_table/baroclinic_test/v1.0/diag_table
+field_table: gs://vcm-fv3config/config/field_table/baroclinic_test/v1.0/field_table
+experiment_name: c48_54ranks_baroclinic
+forcing: gs://vcm-fv3config/data/base_forcing/v1.1/
+orographic_forcing: gs://vcm-fv3config/data/orographic_data/v1.0
+# To use internal test cases, point to an empty ICs directory
+initial_conditions: ""
+namelist:
+  amip_interp_nml:
+    data_set: hurrell
+    date_out_of_range: climo
+    do_sst_pert: false
+    interp_oi_sst: true
+    no_anom_sst: true
+    sst_pert: 0.0
+    sst_pert_type: random
+    use_daily: false
+    use_ncep_ice: true
+    use_ncep_sst: true
+  atmos_model_nml:
+    blocksize: -1
+    chksum_debug: false
+    dycore_only: true
+    fdiag: 1.0
+  cires_ugwp_nml:
+    knob_ugwp_azdir:
+    - 2
+    - 4
+    - 4
+    - 4
+    knob_ugwp_doaxyz: 1
+    knob_ugwp_doheat: 1
+    knob_ugwp_dokdis: 0
+    knob_ugwp_effac:
+    - 1
+    - 1
+    - 1
+    - 1
+    knob_ugwp_ndx4lh: 4
+    knob_ugwp_solver: 2
+    knob_ugwp_source:
+    - 1
+    - 1
+    - 1
+    - 0
+    knob_ugwp_stoch:
+    - 0
+    - 0
+    - 0
+    - 0
+    knob_ugwp_version: 0
+    knob_ugwp_wvspec:
+    - 1
+    - 32
+    - 32
+    - 32
+    launch_level: 55
+  cloud_diagnosis_nml:
+    reiflag: 4
+    reimax: 150.0
+    reimin: 10.0
+    rewmax: 10.0
+    rewmin: 5.0
+  coupler_nml:
+    atmos_nthreads: 1
+    calendar: julian
+    current_date:
+    - 2016
+    - 8
+    - 1
+    - 0
+    - 0
+    - 0
+    days: 0
+    dt_atmos: 225
+    dt_ocean: 225
+    hours: 0
+    memuse_verbose: false
+    minutes: 3
+    months: 0
+    ncores_per_node: 32
+    seconds: 45
+    use_hyper_thread: false
+  diag_manager_nml:
+    max_axes: 240
+    max_files: 106
+    max_num_axis_sets: 100
+    prepend_date: false
+  external_ic_nml:
+    checker_tr: false
+    filtered_terrain: true
+    gfs_dwinds: true
+    levp: 64
+    nt_checker: 0
+  fms_io_nml:
+    checksum_required: false
+    max_files_r: 100
+    max_files_w: 100
+  fms_nml:
+    clock_grain: ROUTINE
+    domains_stack_size: 3000000
+    print_memory_usage: false
+  fv_core_nml:
+    a_imp: 1.0
+    adjust_dry_mass: false
+    beta: 0.0
+    consv_am: false
+    consv_te: 0.0
+    d2_bg: 0.0
+    d2_bg_k1: 0.2
+    d2_bg_k2: 0.1
+    d4_bg: 0.15
+    d_con: 1.0
+    d_ext: 0.0
+    dddmp: 0.5
+    delt_max: 0.002
+    dnats: 1
+    do_sat_adj: true
+    do_vort_damp: true
+    dwind_2d: false
+    external_ic: false
+    fill: true
+    fill_dp: false
+    fv_debug: false
+    fv_sg_adj: 0
+    gfs_phil: false
+    hord_dp: 6
+    hord_mt: 6
+    hord_tm: 6
+    hord_tr: 8
+    hord_vt: 6
+    hydrostatic: false
+    io_layout:
+    - 3
+    - 3
+    k_split: 1
+    ke_bg: 0.0
+    kord_mt: 9
+    kord_tm: -9
+    kord_tr: 9
+    kord_wz: 9
+    layout:
+    - 1
+    - 1
+    make_nh: true
+    mountain: false
+    n_split: 1
+    n_sponge: 48
+    na_init: 1
+    ncep_ic: false
+    nggps_ic: false
+    nord: 3
+    npx: 49
+    npy: 49
+    npz: 79
+    ntiles: 6
+    nudge: false
+    nudge_qv: true
+    nwat: 6
+    p_fac: 0.05
+    phys_hydrostatic: false
+    print_freq: 1
+    range_warn: true
+    reset_eta: false
+    rf_cutoff: 3000.0
+    rf_fast: true
+    tau: 10.0
+    tau_h2o: 0.0
+    use_hydro_pressure: false
+    vtdm4: 0.06
+    warm_start: false
+    z_tracer: true
+  fv_grid_nml: {}
+  gfdl_cloud_microphysics_nml:
+    c_cracw: 0.8
+    c_paut: 0.5
+    c_pgacs: 0.01
+    c_psaci: 0.05
+    ccn_l: 300.0
+    ccn_o: 100.0
+    const_vg: false
+    const_vi: false
+    const_vr: false
+    const_vs: false
+    de_ice: false
+    do_qa: true
+    do_sedi_heat: false
+    do_sedi_w: true
+    dw_land: 0.15
+    dw_ocean: 0.1
+    fast_sat_adj: true
+    fix_negative: true
+    icloud_f: 0
+    irain_f: 0
+    mono_prof: false
+    mp_time: 225.0
+    prog_ccn: false
+    qi0_crt: 8.0e-05
+    qi_lim: 1.0
+    ql_gen: 0.001
+    ql_mlt: 0.002
+    qs0_crt: 0.003
+    qs_mlt: 1.0e-06
+    rad_graupel: true
+    rad_rain: true
+    rad_snow: true
+    rh_inc: 0.2
+    rh_inr: 0.3
+    rh_ins: 0.3
+    rthresh: 1.0e-05
+    sedi_transport: true
+    tau_g2v: 1200.0
+    tau_i2s: 1000.0
+    tau_l2v: 300.0
+    tau_v2l: 90.0
+    use_ccn: true
+    use_ppm: false
+    vg_max: 16.0
+    vi_max: 1.0
+    vr_max: 16.0
+    vs_max: 2.0
+    z_slope_ice: true
+    z_slope_liq: true
+  gfs_physics_nml:
+    c0s_shal: 0.01
+    c1_shal: 0.005
+    cal_pre: false
+    cdmbgwd:
+    - 0.0
+    - 0.0
+    - 0.0
+    - 0.0
+    cnvcld: false
+    cnvgwd: false
+    debug: false
+    do_ocean: false
+    do_deep: false
+    dspheat: true
+    fhcyc: 24.0
+    fhlwr: 1800.0
+    fhswr: 1800.0
+    fhzero: 0.25
+    hybedmf: false
+    iaer: 111
+    ialb: 1
+    ico2: 2
+    iems: 1
+    imfdeepcnv: 2
+    imfshalcnv: 2
+    imp_physics: 11
+    isol: 2
+    isot: 1
+    isubc_lw: 2
+    isubc_sw: 2
+    ivegsrc: 1
+    ldiag3d: false
+    lwhtr: true
+    ncld: 5
+    nst_anl: true
+    pdfcld: false
+    pre_rad: false
+    prslrd0: 0.0
+    random_clds: false
+    redrag: true
+    sfc_override: true
+    satmedmf: true
+    shal_cnv: true
+    swhtr: true
+    trans_trac: true
+    use_ufo: true
+    xkzm_h: 0.1
+    xkzm_m: 0.01
+    xkzminv: 0.0
+  interpolator_nml:
+    interp_method: conserve_great_circle
+  nam_stochy:
+    lat_s: 96
+    lon_s: 192
+    ntrunc: 94
+  sfc_prop_override_nml:
+    ideal_sst: true
+    sst_max: 305
+    sst_profile: 1
+  test_case_nml:
+    test_case: 13
+  namsfc:
+    fabsl: 99999
+    faisl: 99999
+    faiss: 99999
+    fnabsc: grb/global_mxsnoalb.uariz.t1534.3072.1536.rg.grb
+    fnacna: ''
+    fnaisc: grb/CFSR.SEAICE.1982.2012.monthly.clim.grb
+    fnalbc: grb/global_snowfree_albedo.bosu.t1534.3072.1536.rg.grb
+    fnalbc2: grb/global_albedo4.1x1.grb
+    fnglac: grb/global_glacier.2x2.grb
+    fnmskh: grb/seaice_newland.grb
+    fnmxic: grb/global_maxice.2x2.grb
+    fnslpc: grb/global_slope.1x1.grb
+    fnsmcc: grb/global_soilmgldas.t1534.3072.1536.grb
+    fnsnoa: ''
+    fnsnoc: grb/global_snoclim.1.875.grb
+    fnsotc: grb/global_soiltype.statsgo.t1534.3072.1536.rg.grb
+    fntg3c: grb/global_tg3clim.2.6x1.5.grb
+    fntsfa: ''
+    fntsfc: grb/RTGSST.1982.2012.monthly.clim.grb
+    fnvegc: grb/global_vegfrac.0.144.decpercent.grb
+    fnvetc: grb/global_vegtype.igbp.t1534.3072.1536.rg.grb
+    fnvmnc: grb/global_shdmin.0.144x0.144.grb
+    fnvmxc: grb/global_shdmax.0.144x0.144.grb
+    fnzorc: igbp
+    fsicl: 99999
+    fsics: 99999
+    fslpl: 99999
+    fsmcl:
+    - 99999
+    - 99999
+    - 99999
+    fsnol: 99999
+    fsnos: 99999
+    fsotl: 99999
+    ftsfl: 99999
+    ftsfs: 90
+    fvetl: 99999
+    fvmnl: 99999
+    fvmxl: 99999
+    ldebug: false

--- a/tests/serialized_test_data_generation/configs/c48_54ranks_standard.yml
+++ b/tests/serialized_test_data_generation/configs/c48_54ranks_standard.yml
@@ -1,0 +1,318 @@
+data_table: default
+diag_table: default
+field_table: gs://vcm-fv3config/config/field_table/TKE-EDMF/v1.0/field_table
+experiment_name: c48_54ranks_standard
+forcing: gs://vcm-fv3config/data/base_forcing/v1.1/
+orographic_forcing: gs://vcm-fv3config/data/orographic_data/v1.0
+initial_conditions: gs://vcm-fv3config/data/initial_conditions/gfs_initial_conditions/v1.0 
+namelist:
+  amip_interp_nml:
+    data_set: hurrell
+    date_out_of_range: climo
+    do_sst_pert: false
+    interp_oi_sst: true
+    no_anom_sst: true
+    sst_pert: 0.0
+    sst_pert_type: random
+    use_daily: false
+    use_ncep_ice: true
+    use_ncep_sst: true
+  atmos_model_nml:
+    blocksize: -1
+    chksum_debug: false
+    dycore_only: false
+    fdiag: 0.25
+  cires_ugwp_nml:
+    knob_ugwp_azdir:
+    - 2
+    - 4
+    - 4
+    - 4
+    knob_ugwp_doaxyz: 1
+    knob_ugwp_doheat: 1
+    knob_ugwp_dokdis: 0
+    knob_ugwp_effac:
+    - 1
+    - 1
+    - 1
+    - 1
+    knob_ugwp_ndx4lh: 4
+    knob_ugwp_solver: 2
+    knob_ugwp_source:
+    - 1
+    - 1
+    - 1
+    - 0
+    knob_ugwp_stoch:
+    - 0
+    - 0
+    - 0
+    - 0
+    knob_ugwp_version: 0
+    knob_ugwp_wvspec:
+    - 1
+    - 32
+    - 32
+    - 32
+    launch_level: 55
+  cloud_diagnosis_nml:
+    reiflag: 4
+    reimax: 150.0
+    reimin: 10.0
+    rewmax: 10.0
+    rewmin: 5.0
+  coupler_nml:
+    atmos_nthreads: 1
+    calendar: julian
+    current_date:
+    - 2016
+    - 8
+    - 1
+    - 0
+    - 0
+    - 0
+    days: 0
+    dt_atmos: 225
+    dt_ocean: 225
+    hours: 0
+    memuse_verbose: false
+    minutes: 3
+    months: 0
+    ncores_per_node: 32
+    seconds: 45
+    use_hyper_thread: false
+  diag_manager_nml:
+    max_axes: 240
+    max_files: 106
+    max_num_axis_sets: 100
+    prepend_date: false
+  external_ic_nml:
+    checker_tr: false
+    filtered_terrain: true
+    gfs_dwinds: true
+    levp: 64
+    nt_checker: 0
+  fms_io_nml:
+    checksum_required: false
+    max_files_r: 100
+    max_files_w: 100
+  fms_nml:
+    clock_grain: ROUTINE
+    domains_stack_size: 3000000
+    print_memory_usage: false
+  fv_core_nml:
+    a_imp: 1.0
+    adjust_dry_mass: false
+    beta: 0.0
+    consv_am: false
+    consv_te: 0.0
+    d2_bg: 0.0
+    d2_bg_k1: 0.2
+    d2_bg_k2: 0.1
+    d4_bg: 0.15
+    d_con: 1.0
+    d_ext: 0.0
+    dddmp: 0.5
+    delt_max: 0.002
+    dnats: 1
+    do_sat_adj: true
+    do_vort_damp: true
+    dwind_2d: false
+    external_ic: true
+    fill: true
+    fill_dp: false
+    fv_debug: false
+    fv_sg_adj: 600
+    gfs_phil: false
+    hord_dp: 6
+    hord_mt: 6
+    hord_tm: 6
+    hord_tr: 8
+    hord_vt: 6
+    hydrostatic: false
+    io_layout:
+    - 1
+    - 1
+    k_split: 1
+    ke_bg: 0.0
+    kord_mt: 9
+    kord_tm: -9
+    kord_tr: 9
+    kord_wz: 9
+    layout:
+    - 3
+    - 3
+    make_nh: true
+    mountain: false
+    n_split: 1
+    n_sponge: 48
+    na_init: 1
+    ncep_ic: false
+    nggps_ic: true
+    nord: 3
+    npx: 49
+    npy: 49
+    npz: 79
+    ntiles: 6
+    nudge: false
+    nudge_qv: true
+    nwat: 6
+    p_fac: 0.05
+    phys_hydrostatic: false
+    print_freq: 1
+    range_warn: true
+    reset_eta: false
+    rf_cutoff: 3000.0
+    rf_fast: true
+    tau: 10.0
+    tau_h2o: 0.0
+    use_hydro_pressure: false
+    vtdm4: 0.06
+    warm_start: false
+    z_tracer: true
+  fv_grid_nml: {}
+  gfdl_cloud_microphysics_nml:
+    c_cracw: 0.8
+    c_paut: 0.5
+    c_pgacs: 0.01
+    c_psaci: 0.05
+    ccn_l: 300.0
+    ccn_o: 100.0
+    const_vg: false
+    const_vi: false
+    const_vr: false
+    const_vs: false
+    de_ice: false
+    do_qa: true
+    do_sedi_heat: false
+    do_sedi_w: true
+    dw_land: 0.15
+    dw_ocean: 0.1
+    fast_sat_adj: true
+    fix_negative: true
+    icloud_f: 0
+    irain_f: 0
+    mono_prof: false
+    mp_time: 225.0
+    prog_ccn: false
+    qi0_crt: 8.0e-05
+    qi_lim: 1.0
+    ql_gen: 0.001
+    ql_mlt: 0.002
+    qs0_crt: 0.003
+    qs_mlt: 1.0e-06
+    rad_graupel: true
+    rad_rain: true
+    rad_snow: true
+    rh_inc: 0.2
+    rh_inr: 0.3
+    rh_ins: 0.3
+    rthresh: 1.0e-05
+    sedi_transport: true
+    tau_g2v: 1200.0
+    tau_i2s: 1000.0
+    tau_l2v: 300.0
+    tau_v2l: 90.0
+    use_ccn: true
+    use_ppm: false
+    vg_max: 16.0
+    vi_max: 1.0
+    vr_max: 16.0
+    vs_max: 2.0
+    z_slope_ice: true
+    z_slope_liq: true
+  gfs_physics_nml:
+    c0s_shal: 0.01
+    c1_shal: 0.005
+    cal_pre: false
+    cdmbgwd:
+    - 0.0
+    - 0.0
+    - 0.0
+    - 0.0
+    cnvcld: false
+    cnvgwd: false
+    debug: false
+    do_deep: false
+    dspheat: true
+    fhcyc: 24.0
+    fhlwr: 1800.0
+    fhswr: 1800.0
+    fhzero: 0.25
+    hybedmf: false
+    iaer: 111
+    ialb: 1
+    ico2: 2
+    iems: 1
+    imfdeepcnv: 2
+    imfshalcnv: 2
+    imp_physics: 11
+    isol: 2
+    isot: 1
+    isubc_lw: 2
+    isubc_sw: 2
+    ivegsrc: 1
+    ldiag3d: false
+    lwhtr: true
+    ncld: 5
+    nst_anl: true
+    pdfcld: false
+    pre_rad: false
+    prslrd0: 0.0
+    random_clds: false
+    redrag: true
+    satmedmf: true
+    shal_cnv: true
+    swhtr: true
+    trans_trac: true
+    use_ufo: true
+    xkzm_h: 0.1
+    xkzm_m: 0.01
+    xkzminv: 0.0
+  interpolator_nml:
+    interp_method: conserve_great_circle
+  nam_stochy:
+    lat_s: 96
+    lon_s: 192
+    ntrunc: 94
+  namsfc:
+    fabsl: 99999
+    faisl: 99999
+    faiss: 99999
+    fnabsc: grb/global_mxsnoalb.uariz.t1534.3072.1536.rg.grb
+    fnacna: ''
+    fnaisc: grb/CFSR.SEAICE.1982.2012.monthly.clim.grb
+    fnalbc: grb/global_snowfree_albedo.bosu.t1534.3072.1536.rg.grb
+    fnalbc2: grb/global_albedo4.1x1.grb
+    fnglac: grb/global_glacier.2x2.grb
+    fnmskh: grb/seaice_newland.grb
+    fnmxic: grb/global_maxice.2x2.grb
+    fnslpc: grb/global_slope.1x1.grb
+    fnsmcc: grb/global_soilmgldas.t1534.3072.1536.grb
+    fnsnoa: ''
+    fnsnoc: grb/global_snoclim.1.875.grb
+    fnsotc: grb/global_soiltype.statsgo.t1534.3072.1536.rg.grb
+    fntg3c: grb/global_tg3clim.2.6x1.5.grb
+    fntsfa: ''
+    fntsfc: grb/RTGSST.1982.2012.monthly.clim.grb
+    fnvegc: grb/global_vegfrac.0.144.decpercent.grb
+    fnvetc: grb/global_vegtype.igbp.t1534.3072.1536.rg.grb
+    fnvmnc: grb/global_shdmin.0.144x0.144.grb
+    fnvmxc: grb/global_shdmax.0.144x0.144.grb
+    fnzorc: igbp
+    fsicl: 99999
+    fsics: 99999
+    fslpl: 99999
+    fsmcl:
+    - 99999
+    - 99999
+    - 99999
+    fsnol: 99999
+    fsnos: 99999
+    fsotl: 99999
+    ftsfl: 99999
+    ftsfs: 90
+    fvetl: 99999
+    fvmnl: 99999
+    fvmxl: 99999
+    ldebug: false

--- a/tests/serialized_test_data_generation/make_all_datasets.sh
+++ b/tests/serialized_test_data_generation/make_all_datasets.sh
@@ -39,7 +39,7 @@ fi
 
 # generate list of experiments (and abort if none found)
 set +e
-EXPERIMENTS=`/bin/ls -1d ${EXPERIMENT_DIR}/${EXPERIMENT_PATTERN} 2> /dev/null`
+EXPERIMENTS=`/bin/ls -1d ${EXPERIMENT_DIR}/${EXPERIMENT_PATTERN} 2> /dev/null | sort -t '_' -n -k1.2 -k2.1`
 set -e
 if [ -z "${EXPERIMENTS}" ] ; then
     echo "Error: No matching experiment files for pattern ${EXPERIMENT_PATTERN} in ${EXPERIMENT_DIR} found."

--- a/tests/serialized_test_data_generation/make_all_datasets.sh
+++ b/tests/serialized_test_data_generation/make_all_datasets.sh
@@ -3,13 +3,17 @@
 # This is a utility script which allows to generate serialized data for multiple
 # experiment files matching a certain search pattern.
 
+# 2021/01/22 Oliver Fuhrer, Vulcan Inc, oliverf@vulcan.com
+
 # Environment variables:
 # EXPERIMENT_PATTERN  search pattern for experiment files (default: *.yml)
 # FORTRAN_VERSION     override value in Makefile (see docu there)
-# VALIDATE_ONLY       only compare data against version stored in cloud (instead of pushing)
+# VALIDATE_ONLY       set to "true" to only compare data against version stored in cloud (instead of pushing)
+# FORCE_PUSH          set to "true" to overwrite pre-existing data on cloud storage
 
-# stop on all errors
+# stop on all errors (also on error in a pipe-redirection)
 set -e
+set -o pipefail
 
 # directory containing the experiment files
 EXPERIMENT_DIR=configs
@@ -54,9 +58,9 @@ for exp_file in ${EXPERIMENTS} ; do
       export SER_ENV="ALL"
   fi
   if [ "${VALIDATE_ONLY}" == "true" ] ; then
-      EXPERIMENT=${exp_name} make generate_data validate_data
+      EXPERIMENT=${exp_name} make generate_data validate_data clean
   else
-      EXPERIMENT=${exp_name} make generate_data pack_data push_data
+      EXPERIMENT=${exp_name} make generate_data pack_data push_data clean
   fi
   echo "====================================================="
   echo ""


### PR DESCRIPTION
This PR removes data and run directories after each configuration in order to reduce disk space usage when generating regression data. It also does a cleanup of the Jenkins action script that is responsible for generating the regression data.
