### PR TITLE
fix missing gzip option for tar

### DIFF
--- a/.jenkins/actions/benchmark_bare_metal.sh
+++ b/.jenkins/actions/benchmark_bare_metal.sh
@@ -159,7 +159,7 @@ for config in ${CONFIGURATION_LIST} ; do
         /bin/rm -f ${tarfile}
     fi
     mkdir -p `dirname ${tarfile}`
-    (cd ${work_dir}/..; tar cvf ${tarfile} ${work_name})
+    (cd ${work_dir}/..; tar cvfz ${tarfile} ${work_name})
 
 done
 

--- a/.jenkins/actions/benchmark_bare_metal.sh
+++ b/.jenkins/actions/benchmark_bare_metal.sh
@@ -121,6 +121,7 @@ for config in ${CONFIGURATION_LIST} ; do
 
     # create the run directory (will erase pre-existing directories) and run benchmark
     # note: this waits until completion
+    partition=normal
     ./run_benchmark.py \
         --hyperthreading \
         --threads_per_rank=4 \


### PR DESCRIPTION
This PR incorporates two bugifxes:
1) When running the benchmark on Piz Daint and tar'ing the latest run directory, the gzip option has been forgotten in the options to tar, even though the target files is named *.tar.gz.
2) The variable ${partition} was not defined.