### PR TITLE
Fix uninitialized value

### DIFF
--- a/FV3/atmos_cubed_sphere/driver/fvGFS/fv_nggps_diag.F90
+++ b/FV3/atmos_cubed_sphere/driver/fvGFS/fv_nggps_diag.F90
@@ -112,7 +112,7 @@ module fv_nggps_diags_mod
  integer :: id_maxvort02,kstt_maxvort02,kend_maxvort02
  integer :: isco, ieco, jsco, jeco, npzo, ncnsto
  integer :: isdo, iedo, jsdo, jedo
- integer :: nlevs
+ integer :: nlevs = 0
  logical :: hydrostatico
  integer, allocatable :: id_tracer(:), all_axes(:)
  integer, allocatable :: kstt_tracer(:), kend_tracer(:)

--- a/FV3/atmos_cubed_sphere/driver/fvGFS/fv_nggps_diag.F90
+++ b/FV3/atmos_cubed_sphere/driver/fvGFS/fv_nggps_diag.F90
@@ -112,7 +112,7 @@ module fv_nggps_diags_mod
  integer :: id_maxvort02,kstt_maxvort02,kend_maxvort02
  integer :: isco, ieco, jsco, jeco, npzo, ncnsto
  integer :: isdo, iedo, jsdo, jedo
- integer :: nlevs = 0
+ integer :: nlevs
  logical :: hydrostatico
  integer, allocatable :: id_tracer(:), all_axes(:)
  integer, allocatable :: kstt_tracer(:), kend_tracer(:)
@@ -183,6 +183,7 @@ contains
     id_tracer(:) = 0
     kstt_tracer(:) = 0
     kend_tracer(:) = 0
+    nlevs = 0
 
     if (Atm(n)%flagstruct%write_3d_diags) then
 !-------------------


### PR DESCRIPTION
The value of `nlevs` in `fv_nggps_diag.F90` is never initialized, which causes an error under some circumstances.