### PR TITLE
Fix to avoid undefined values in radiation driver

### DIFF
--- a/FV3/gfsphysics/GFS_layer/GFS_radiation_driver.F90
+++ b/FV3/gfsphysics/GFS_layer/GFS_radiation_driver.F90
@@ -1962,6 +1962,7 @@
 
           if (Model%swhtr) then
             Radtend%swhc(:,:) = 0
+            cldtausw(:,:) = 0.0
           endif
 
         endif                  ! end_if_nday


### PR DESCRIPTION
This fix avoids the use of undefined values in the radiation driver and as a consequence enables debug mode for the Intel compiler.

This fix does not affect results and only affects performance in a negligible way.
