### PR TITLE
Use --cache-from for docker builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,17 +20,12 @@ jobs:
             echo $ENCODED_GCR_KEY | base64 -d > $GOOGLE_APPLICATION_CREDENTIALS
             echo "export GCLOUD_SERVICE_KEY=\$(echo \$ENCODED_GCR_KEY | base64 --decode)" >> $BASH_ENV
       - gcp-gcr/gcr-auth
-      - run: 
-          name: "Pull dependency images"
-          command: |
-            echo "$ENCODED_GCR_KEY" | base64 --decode | docker login --username _json_key --password-stdin https://gcr.io
-            make pull_deps
       - run:
           name: "Pull Submodules"
           command: |
             git submodule init
             git submodule update
-      - run: DOCKER_BUILDKIT=1 BUILDKIT_PROGRESS=plain BUILD_FROM_INTERMEDIATE=y make build build_debug build_serialize
+      - run: make build build_debug build_serialize
       - restore_cache:
           keys:
             - v1.4-{{ checksum "requirements.txt"}}
@@ -53,7 +48,7 @@ jobs:
           command: |
             make test
           no_output_timeout: 1200
-      - run: make push_deps
+      - run: make push
       - run:
           name: "Delete data files"
           command: |

--- a/docker/build_docker_cached.sh
+++ b/docker/build_docker_cached.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -e
+
+cacheImage="$1"
+shift 1
+
+export DOCKER_BUILDKIT=1
+export BUILDKIT_PROGRESS=plain
+
+if [[ -z "$GOOGLE_APPLICATION_CREDENTIALS" ]]
+then
+    echo "Google authentication not configured. "
+    echo "Please set the GOOGLE_APPLICATION_CREDENTIALS environmental variable."
+    exit 1
+fi
+
+docker build \
+    --secret id=gcp,src="$GOOGLE_APPLICATION_CREDENTIALS" \
+    --build-arg BUILDKIT_INLINE_CACHE=1 \
+    --build-arg COMMIT_SHA_ARG="$(git rev-parse HEAD)" \
+    --cache-from "$cacheImage" $@

--- a/docker/build_docker_cached.sh
+++ b/docker/build_docker_cached.sh
@@ -19,4 +19,5 @@ docker build \
     --secret id=gcp,src="$GOOGLE_APPLICATION_CREDENTIALS" \
     --build-arg BUILDKIT_INLINE_CACHE=1 \
     --build-arg COMMIT_SHA_ARG="$(git rev-parse HEAD)" \
-    --cache-from "$cacheImage" $@
+    $@
+    # --cache-from "$cacheImage" $@


### PR DESCRIPTION
removes the need for manual management of the "deps" images