### PR TITLE
Convert empty string to empty list for no assets in baroclinic yaml

### DIFF
--- a/tests/pytest/config/baroclinic.yml
+++ b/tests/pytest/config/baroclinic.yml
@@ -5,7 +5,7 @@ experiment_name: baroclinic
 forcing: gs://vcm-fv3config/data/base_forcing/v1.1/
 orographic_forcing: gs://vcm-fv3config/data/orographic_data/v1.0
 # To use internal test cases, point to an empty ICs directory
-initial_conditions: ""
+initial_conditions: []
 namelist:
   amip_interp_nml:
     data_set: hurrell


### PR DESCRIPTION
Empty string causes a FileNotFoundError when using a pypi-installed version of fv3config.

The issue does not occur for local `pip install -e` installs. We don't know why, this should possibly be investigated.