### PR TITLE
Hotfix to change GCC version back to 9.3.0 after Daint upgrade

### DIFF
--- a/FV3/conf/modules.fv3.daint_gnu
+++ b/FV3/conf/modules.fv3.daint_gnu
@@ -4,6 +4,7 @@
 ##
 module load daint-gpu
 module switch PrgEnv-cray PrgEnv-gnu
+module switch gcc gcc/9.3.0
 module load cray-netcdf
 
 ##


### PR DESCRIPTION
It does what it says.
This PR only affects bare-metal builds on Piz Daint.