### PR TITLE
Reduce runtime of test on Piz Daint

### DIFF
--- a/.jenkins/actions/build_bare_metal.sh
+++ b/.jenkins/actions/build_bare_metal.sh
@@ -160,8 +160,8 @@ EOF1
       sed -i 's|^ *days *= *[0-9][0-9]* *$|days = 0|g' input.nml
       sed -i 's|^ *hours *= *[0-9][0-9]* *$|hours = 1|g' input.nml
     else
-      sed -i 's|^ *days *= *[0-9][0-9]* *$|days = 1|g' input.nml
-      sed -i 's|^ *hours *= *[0-9][0-9]* *$|hours = 0|g' input.nml
+      sed -i 's|^ *days *= *[0-9][0-9]* *$|days = 0|g' input.nml
+      sed -i 's|^ *hours *= *[0-9][0-9]* *$|hours = 12|g' input.nml
     fi
 
     jobfile=job
@@ -174,6 +174,7 @@ EOF1
     sed -i 's|<NTASKS>|12|g' ${jobfile}
     sed -i 's|<NTASKSPERNODE>|'"12"'|g' ${jobfile}
     sed -i 's|<CPUSPERTASK>|1|g' ${jobfile}
+    sed -i 's|--time=.*$|--time=01:00:00|g' ${jobfile}
 
     set +e
     launch_job ${jobfile} 3000


### PR DESCRIPTION
The tests of the bare metal executables have been running over since the upgrade. This is weird and will require further investigation. This PR should unblock the building of the executables so that the performance tests can be run on fresh executables in order to see what the actual change in performance for a more realistic setup actually is.