### PR TITLE
Add namelist flag to restore ability to prescribe SST from Python wrapper

### DIFF
--- a/FV3/gfsphysics/GFS_layer/GFS_physics_driver.F90
+++ b/FV3/gfsphysics/GFS_layer/GFS_physics_driver.F90
@@ -730,7 +730,7 @@ module module_physics_driver
       endif
 
       if (Model%prescribe_sst_from_wrapper) then
-        sea_surface_temperature => Statein%sst_from_wrapper
+        sea_surface_temperature => Sfcprop%tsfco
       else
         sea_surface_temperature => Sfcprop%tsfc
       endif

--- a/FV3/gfsphysics/GFS_layer/GFS_physics_driver.F90
+++ b/FV3/gfsphysics/GFS_layer/GFS_physics_driver.F90
@@ -2093,6 +2093,16 @@ module module_physics_driver
         enddo
       endif
 
+      if (Model%prescribe_sst_from_wrapper) then
+        do i = 1, im
+          if (islmsk(i) == 0 ) then
+            Sfcprop%tsfc(i) = Statein%sst_from_wrapper(i) + Model%sst_perturbation
+            Sfcprop%tsfco(i) = Statein%sst_from_wrapper(i) + Model%sst_perturbation
+            tsfc3(i,3) = Statein%sst_from_wrapper(i) + Model%sst_perturbation
+          endif
+        enddo
+      endif
+
       do i=1,im
         Diag%epi(i)     = ep1d(i)
         Diag%dlwsfci(i) = adjsfcdlw_for_lsm(i)

--- a/FV3/gfsphysics/GFS_layer/GFS_physics_driver.F90
+++ b/FV3/gfsphysics/GFS_layer/GFS_physics_driver.F90
@@ -729,7 +729,7 @@ module module_physics_driver
         adjsfcnsw_for_lsm => adjsfcnsw
       endif
 
-      if (Model%prescribe_sst_from_wrapper) then
+      if (Model%override_sea_surface_temperature) then
         sea_surface_temperature => Sfcprop%tsfco
       else
         sea_surface_temperature => Sfcprop%tsfc

--- a/FV3/gfsphysics/GFS_layer/GFS_physics_driver.F90
+++ b/FV3/gfsphysics/GFS_layer/GFS_physics_driver.F90
@@ -1135,7 +1135,7 @@ module module_physics_driver
         do i = 1, IM
           frland(i) = zero
           if (islmsk(i) == 0) then
-            Sfcprop%tsfco(i) = Sfcprop%tsfc(i)
+            Sfcprop%tsfco(i) = sea_surface_temperature(i)
             wet(i)  = .true.
             fice(i) = zero
           elseif (islmsk(i) == 1) then

--- a/FV3/gfsphysics/GFS_layer/GFS_physics_driver.F90
+++ b/FV3/gfsphysics/GFS_layer/GFS_physics_driver.F90
@@ -674,7 +674,7 @@ module module_physics_driver
       real(kind=kind_phys), allocatable, dimension(:,:) :: den
       real(kind=kind_phys), allocatable, dimension(:,:) :: dqdt_work
       real(kind=kind_phys), pointer :: adjsfcdlw_for_lsm(:), adjsfcdsw_for_lsm(:), adjsfcnsw_for_lsm(:)
-      real(kind=kind_phys), pointer :: ocean_surface_temperature(:)
+      real(kind=kind_phys), pointer :: sea_surface_temperature(:)
       integer :: nwat
 
       !! Initialize local variables (mainly for debugging purposes, because the
@@ -730,9 +730,9 @@ module module_physics_driver
       endif
 
       if (Model%use_climatological_sst) then
-        ocean_surface_temperature => Sfcprop%tsfc
+        sea_surface_temperature => Sfcprop%tsfc
       else
-        ocean_surface_temperature => Sfcprop%tsfco
+        sea_surface_temperature => Sfcprop%tsfco
       endif
 !-------
 ! For COORDE-2019 averaging with fwindow, it was done before
@@ -1135,7 +1135,7 @@ module module_physics_driver
         do i = 1, IM
           frland(i) = zero
           if (islmsk(i) == 0) then
-            Sfcprop%tsfco(i) = ocean_surface_temperature(i)
+            Sfcprop%tsfco(i) = sea_surface_temperature(i)
             wet(i)  = .true.
             fice(i) = zero
           elseif (islmsk(i) == 1) then

--- a/FV3/gfsphysics/GFS_layer/GFS_physics_driver.F90
+++ b/FV3/gfsphysics/GFS_layer/GFS_physics_driver.F90
@@ -674,6 +674,7 @@ module module_physics_driver
       real(kind=kind_phys), allocatable, dimension(:,:) :: den
       real(kind=kind_phys), allocatable, dimension(:,:) :: dqdt_work
       real(kind=kind_phys), pointer :: adjsfcdlw_for_lsm(:), adjsfcdsw_for_lsm(:), adjsfcnsw_for_lsm(:)
+      real(kind=kind_phys), pointer :: sea_surface_temperature(:)
       integer :: nwat
 
       !! Initialize local variables (mainly for debugging purposes, because the
@@ -728,6 +729,11 @@ module module_physics_driver
         adjsfcnsw_for_lsm => adjsfcnsw
       endif
 
+      if (Model%prescribe_sst_from_wrapper) then
+        sea_surface_temperature => Statein%sst_from_wrapper
+      else
+        sea_surface_temperature => Sfcprop%tsfc
+      endif
 !-------
 ! For COORDE-2019 averaging with fwindow, it was done before
 ! 3Diag fixes and averaging ingested using "fdaily"-factor
@@ -2089,16 +2095,6 @@ module module_physics_driver
             Sfcprop%tsfc(i) = Statein%atm_ts(i) + Model%sst_perturbation
             Sfcprop%tsfco(i) = Statein%atm_ts(i) + Model%sst_perturbation
             tsfc3(i,3) = Statein%atm_ts(i) + Model%sst_perturbation
-          endif
-        enddo
-      endif
-
-      if (Model%prescribe_sst_from_wrapper) then
-        do i = 1, im
-          if (islmsk(i) == 0 ) then
-            Sfcprop%tsfc(i) = Statein%sst_from_wrapper(i) + Model%sst_perturbation
-            Sfcprop%tsfco(i) = Statein%sst_from_wrapper(i) + Model%sst_perturbation
-            tsfc3(i,3) = Statein%sst_from_wrapper(i) + Model%sst_perturbation
           endif
         enddo
       endif

--- a/FV3/gfsphysics/GFS_layer/GFS_physics_driver.F90
+++ b/FV3/gfsphysics/GFS_layer/GFS_physics_driver.F90
@@ -729,7 +729,7 @@ module module_physics_driver
         adjsfcnsw_for_lsm => adjsfcnsw
       endif
 
-      if (Model%override_sea_surface_temperature) then
+      if (Model%override_ocean_surface_temperature) then
         sea_surface_temperature => Sfcprop%tsfco
       else
         sea_surface_temperature => Sfcprop%tsfc

--- a/FV3/gfsphysics/GFS_layer/GFS_physics_driver.F90
+++ b/FV3/gfsphysics/GFS_layer/GFS_physics_driver.F90
@@ -729,10 +729,10 @@ module module_physics_driver
         adjsfcnsw_for_lsm => adjsfcnsw
       endif
 
-      if (Model%override_ocean_surface_temperature) then
-        ocean_surface_temperature => Sfcprop%tsfco
-      else
+      if (Model%use_climatological_sst) then
         ocean_surface_temperature => Sfcprop%tsfc
+      else
+        ocean_surface_temperature => Sfcprop%tsfco
       endif
 !-------
 ! For COORDE-2019 averaging with fwindow, it was done before

--- a/FV3/gfsphysics/GFS_layer/GFS_physics_driver.F90
+++ b/FV3/gfsphysics/GFS_layer/GFS_physics_driver.F90
@@ -674,7 +674,7 @@ module module_physics_driver
       real(kind=kind_phys), allocatable, dimension(:,:) :: den
       real(kind=kind_phys), allocatable, dimension(:,:) :: dqdt_work
       real(kind=kind_phys), pointer :: adjsfcdlw_for_lsm(:), adjsfcdsw_for_lsm(:), adjsfcnsw_for_lsm(:)
-      real(kind=kind_phys), pointer :: sea_surface_temperature(:)
+      real(kind=kind_phys), pointer :: ocean_surface_temperature(:)
       integer :: nwat
 
       !! Initialize local variables (mainly for debugging purposes, because the
@@ -730,9 +730,9 @@ module module_physics_driver
       endif
 
       if (Model%override_ocean_surface_temperature) then
-        sea_surface_temperature => Sfcprop%tsfco
+        ocean_surface_temperature => Sfcprop%tsfco
       else
-        sea_surface_temperature => Sfcprop%tsfc
+        ocean_surface_temperature => Sfcprop%tsfc
       endif
 !-------
 ! For COORDE-2019 averaging with fwindow, it was done before
@@ -1135,7 +1135,7 @@ module module_physics_driver
         do i = 1, IM
           frland(i) = zero
           if (islmsk(i) == 0) then
-            Sfcprop%tsfco(i) = sea_surface_temperature(i)
+            Sfcprop%tsfco(i) = ocean_surface_temperature(i)
             wet(i)  = .true.
             fice(i) = zero
           elseif (islmsk(i) == 1) then

--- a/FV3/gfsphysics/GFS_layer/GFS_typedefs.F90
+++ b/FV3/gfsphysics/GFS_layer/GFS_typedefs.F90
@@ -1084,7 +1084,7 @@ module GFS_typedefs
     logical :: iau_filter_increments
     real(kind=kind_phys) :: sst_perturbation  ! Sea surface temperature perturbation to climatology or nudging SST (default 0.0 K)
     logical :: override_surface_radiative_fluxes  ! Whether to use Statein to override the surface radiative fluxes
-    logical :: prescribe_sst_from_wrapper  ! Whether to prescribe the sea surface temperature via the Python wrapper
+    logical :: override_sea_surface_temperature  ! Whether to allow the Python wrapper to override the sea surface temperature
 #ifdef CCPP
     ! From physcons.F90, updated/set in control_initialize
     real(kind=kind_phys) :: dxinv           ! inverse scaling factor for critical relative humidity, replaces dxinv in physcons.F90
@@ -3129,7 +3129,7 @@ module GFS_typedefs
 
     real(kind=kind_phys) :: sst_perturbation = 0.0  ! Sea surface temperature perturbation [K]
     logical :: override_surface_radiative_fluxes = .false.
-    logical :: prescribe_sst_from_wrapper = .false.
+    logical :: override_sea_surface_temperature = .false.
 !--- END NAMELIST VARIABLES
 
     NAMELIST /gfs_physics_nml/                                                              &
@@ -3221,7 +3221,7 @@ module GFS_typedefs
                           !--- aerosol scavenging factors ('name:value' string array)
                                fscav_aero, &
                                sst_perturbation,                                            & 
-                               override_surface_radiative_fluxes, prescribe_sst_from_wrapper
+                               override_surface_radiative_fluxes, override_sea_surface_temperature
 
 !--- other parameters 
     integer :: nctp    =  0                !< number of cloud types in CS scheme
@@ -3690,7 +3690,7 @@ module GFS_typedefs
 
     Model%sst_perturbation = sst_perturbation
     Model%override_surface_radiative_fluxes = override_surface_radiative_fluxes
-    Model%prescribe_sst_from_wrapper = prescribe_sst_from_wrapper
+    Model%override_sea_surface_temperature = override_sea_surface_temperature
 !--- tracer handling
     Model%ntrac            = size(tracer_names)
 #ifdef CCPP
@@ -4499,7 +4499,7 @@ module GFS_typedefs
       print *, ' isot              : ', Model%isot
       print *, ' sst_perturbation  : ', Model%sst_perturbation
       print *, ' override_surface_radiative_fluxes: ', Model%override_surface_radiative_fluxes
-      print *, ' prescribe_sst_from_wrapper: ', Model%prescribe_sst_from_wrapper
+      print *, ' override_sea_surface_temperature: ', Model%override_sea_surface_temperature
       if (Model%lsm == Model%lsm_noahmp) then
       print *, ' Noah MP LSM is used, the options are'
       print *, ' iopt_dveg         : ', Model%iopt_dveg

--- a/FV3/gfsphysics/GFS_layer/GFS_typedefs.F90
+++ b/FV3/gfsphysics/GFS_layer/GFS_typedefs.F90
@@ -193,7 +193,6 @@ module GFS_typedefs
     real (kind=kind_phys), pointer :: adjsfcdlw_override(:) => null()  !< override to the downward longwave radiation flux at the surface
     real (kind=kind_phys), pointer :: adjsfcdsw_override(:) => null()  !< override to the downward shortwave radiation flux at the surface
     real (kind=kind_phys), pointer :: adjsfcnsw_override(:) => null()  !< override to the net shortwave radiation flux at the surface
-    real (kind=kind_phys), pointer :: sst_from_wrapper(:) => null()    !< sea surface temperature set by the Python wrapper
     contains
       procedure :: create  => statein_create  !<   allocate array data
   end type GFS_statein_type
@@ -2035,11 +2034,6 @@ module GFS_typedefs
       Statein%adjsfcdlw_override = 0.0
       Statein%adjsfcdsw_override = 0.0
       Statein%adjsfcnsw_override = 0.0
-    endif
-
-    if (Model%prescribe_sst_from_wrapper) then
-      allocate(Statein%sst_from_wrapper(IM))
-      Statein%sst_from_wrapper = 0.0
     endif
   end subroutine statein_create
 

--- a/FV3/gfsphysics/GFS_layer/GFS_typedefs.F90
+++ b/FV3/gfsphysics/GFS_layer/GFS_typedefs.F90
@@ -1084,7 +1084,7 @@ module GFS_typedefs
     logical :: iau_filter_increments
     real(kind=kind_phys) :: sst_perturbation  ! Sea surface temperature perturbation to climatology or nudging SST (default 0.0 K)
     logical :: override_surface_radiative_fluxes  ! Whether to use Statein to override the surface radiative fluxes
-    logical :: override_sea_surface_temperature  ! Whether to allow the Python wrapper to override the sea surface temperature
+    logical :: override_ocean_surface_temperature  ! Whether to allow the Python wrapper to override the sea surface temperature
 #ifdef CCPP
     ! From physcons.F90, updated/set in control_initialize
     real(kind=kind_phys) :: dxinv           ! inverse scaling factor for critical relative humidity, replaces dxinv in physcons.F90
@@ -3129,7 +3129,7 @@ module GFS_typedefs
 
     real(kind=kind_phys) :: sst_perturbation = 0.0  ! Sea surface temperature perturbation [K]
     logical :: override_surface_radiative_fluxes = .false.
-    logical :: override_sea_surface_temperature = .false.
+    logical :: override_ocean_surface_temperature = .false.
 !--- END NAMELIST VARIABLES
 
     NAMELIST /gfs_physics_nml/                                                              &
@@ -3221,7 +3221,7 @@ module GFS_typedefs
                           !--- aerosol scavenging factors ('name:value' string array)
                                fscav_aero, &
                                sst_perturbation,                                            & 
-                               override_surface_radiative_fluxes, override_sea_surface_temperature
+                               override_surface_radiative_fluxes, override_ocean_surface_temperature
 
 !--- other parameters 
     integer :: nctp    =  0                !< number of cloud types in CS scheme
@@ -3690,7 +3690,7 @@ module GFS_typedefs
 
     Model%sst_perturbation = sst_perturbation
     Model%override_surface_radiative_fluxes = override_surface_radiative_fluxes
-    Model%override_sea_surface_temperature = override_sea_surface_temperature
+    Model%override_ocean_surface_temperature = override_ocean_surface_temperature
 !--- tracer handling
     Model%ntrac            = size(tracer_names)
 #ifdef CCPP
@@ -4499,7 +4499,7 @@ module GFS_typedefs
       print *, ' isot              : ', Model%isot
       print *, ' sst_perturbation  : ', Model%sst_perturbation
       print *, ' override_surface_radiative_fluxes: ', Model%override_surface_radiative_fluxes
-      print *, ' override_sea_surface_temperature: ', Model%override_sea_surface_temperature
+      print *, ' override_ocean_surface_temperature: ', Model%override_ocean_surface_temperature
       if (Model%lsm == Model%lsm_noahmp) then
       print *, ' Noah MP LSM is used, the options are'
       print *, ' iopt_dveg         : ', Model%iopt_dveg

--- a/FV3/gfsphysics/GFS_layer/GFS_typedefs.F90
+++ b/FV3/gfsphysics/GFS_layer/GFS_typedefs.F90
@@ -1084,7 +1084,7 @@ module GFS_typedefs
     logical :: iau_filter_increments
     real(kind=kind_phys) :: sst_perturbation  ! Sea surface temperature perturbation to climatology or nudging SST (default 0.0 K)
     logical :: override_surface_radiative_fluxes  ! Whether to use Statein to override the surface radiative fluxes
-    logical :: override_ocean_surface_temperature  ! Whether to allow the Python wrapper to override the sea surface temperature
+    logical :: use_climatological_sst  ! Whether to allow the Python wrapper to override the sea surface temperature
 #ifdef CCPP
     ! From physcons.F90, updated/set in control_initialize
     real(kind=kind_phys) :: dxinv           ! inverse scaling factor for critical relative humidity, replaces dxinv in physcons.F90
@@ -3129,7 +3129,7 @@ module GFS_typedefs
 
     real(kind=kind_phys) :: sst_perturbation = 0.0  ! Sea surface temperature perturbation [K]
     logical :: override_surface_radiative_fluxes = .false.
-    logical :: override_ocean_surface_temperature = .false.
+    logical :: use_climatological_sst = .true.
 !--- END NAMELIST VARIABLES
 
     NAMELIST /gfs_physics_nml/                                                              &
@@ -3221,7 +3221,7 @@ module GFS_typedefs
                           !--- aerosol scavenging factors ('name:value' string array)
                                fscav_aero, &
                                sst_perturbation,                                            & 
-                               override_surface_radiative_fluxes, override_ocean_surface_temperature
+                               override_surface_radiative_fluxes, use_climatological_sst
 
 !--- other parameters 
     integer :: nctp    =  0                !< number of cloud types in CS scheme
@@ -3690,7 +3690,7 @@ module GFS_typedefs
 
     Model%sst_perturbation = sst_perturbation
     Model%override_surface_radiative_fluxes = override_surface_radiative_fluxes
-    Model%override_ocean_surface_temperature = override_ocean_surface_temperature
+    Model%use_climatological_sst = use_climatological_sst
 !--- tracer handling
     Model%ntrac            = size(tracer_names)
 #ifdef CCPP
@@ -4499,7 +4499,7 @@ module GFS_typedefs
       print *, ' isot              : ', Model%isot
       print *, ' sst_perturbation  : ', Model%sst_perturbation
       print *, ' override_surface_radiative_fluxes: ', Model%override_surface_radiative_fluxes
-      print *, ' override_ocean_surface_temperature: ', Model%override_ocean_surface_temperature
+      print *, ' use_climatological_sst: ', Model%use_climatological_sst
       if (Model%lsm == Model%lsm_noahmp) then
       print *, ' Noah MP LSM is used, the options are'
       print *, ' iopt_dveg         : ', Model%iopt_dveg


### PR DESCRIPTION
#93 restored the default behavior of the model SSTs, which was good, because it allowed the model SST to follow the climatology, but it broke our ability to set the sea surface temperature from the Python wrapper.  This PR adds a namelist flag that allows us to toggle between the two behaviors.