### PR TITLE
fix dns setting for mac builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,6 +27,10 @@ jobs:
             git submodule update
       - run: |
           nix-build -j 4 -A fv3 | cachix push vulcanclimatemodeling
+          # additional changes to the DNS settings are needed for mac
+          # https://stackoverflow.com/questions/23112515/mpich2-gethostbyname-failed
+          echo "127.0.0.1 $HOSTNAME" | sudo tee -a /etc/hosts
+
       - run:
           name: Test
           command: nix-shell tests.nix --run tox


### PR DESCRIPTION
The Mac build were failing with this error:
```
Fatal error in MPI_Init: Invalid group, error stack:
MPIR_Init_thread(586)..............: 
MPID_Init(224).....................: channel initialization failed
MPIDI_CH3_Init(105)................: 
MPID_nem_init(324).................: 
MPID_nem_tcp_init(175).............: 
MPID_nem_tcp_get_business_card(401): 
MPID_nem_tcp_init(373).............: gethostbyname failed, static.38.39.189.154.cyberlynk.net (errno 0)
```

MPI on macs require some special DNS settings, see the stackoverflow link in the comment for more info.