### PR TITLE
nix: use git for FV3 source

### DIFF
--- a/nix/fv3/default.nix
+++ b/nix/fv3/default.nix
@@ -13,6 +13,11 @@
   , gfortran
   , getopt
 } :
+let 
+  src = builtins.fetchGit {
+    url = ../..;
+  };
+in
 stdenv.mkDerivation {
   name = "fv3";
   buildInputs = [
@@ -34,8 +39,8 @@ stdenv.mkDerivation {
   ];
 
   srcs = [
-    ../../FV3/.
-    ../../stochastic_physics/.
+    "${src}/FV3"
+    "${src}/stochastic_physics"
   ];
 
 # need some fancy logic to unpack the two source directories


### PR DESCRIPTION
This means that unstaged changes will not incur any rebuilds, and files
that aren't in version control (e.g. build artifacts) will not cause nix
to rebuild.

If you do want something to be included in a rebuild, it will need to be
staged to the git index (e.g. using git add).