### PR TITLE
Remove conditional rounding of `fhzero` in computing diag_time

### DIFF
--- a/FV3/atmos_model.F90
+++ b/FV3/atmos_model.F90
@@ -952,11 +952,7 @@ subroutine update_atmos_model_state (Atmos)
                             Atm(mytile)%coarse_graining%write_coarse_diagnostics, &
                             IPD_Diag_coarse, &
                             Atm(mytile)%delp(is:ie,js:je,:), Atmos%coarsening_strategy, Atm(mytile)%ptop)
-      if (nint(IPD_Control%fhzero) > 0) then 
-        if (mod(isec,3600*nint(IPD_Control%fhzero)) == 0) diag_time = Atmos%Time
-      else
-        if (mod(isec,nint(3600*IPD_Control%fhzero)) == 0) diag_time = Atmos%Time
-      endif
+      if (mod(isec,nint(3600*IPD_Control%fhzero)) == 0) diag_time = Atmos%Time
       call diag_send_complete_instant (Atmos%Time)
     endif
     call mpp_clock_end(diagClock)


### PR DESCRIPTION
This PR implements the fix proposed for #193 within the issue description.  We don't typically output physics diagnostics with frequencies that cause an issue, but I think it would still be good to fix this, as the behavior without this change is quite unexpected.  This [notebook](https://github.com/VulcanClimateModeling/explore/blob/master/spencerc/2021-05-21-physics-diags-fix/2021-05-21-physics-diags-fix.ipynb) illustrates that this fix addresses the issue using an output frequency of 1.5 hours.

Closes #193