### PR TITLE
Remove dependency on orography files for baroclinic configurations

### DIFF
--- a/tests/serialized_test_data_generation/configs/c320_6ranks_baroclinic.yml
+++ b/tests/serialized_test_data_generation/configs/c320_6ranks_baroclinic.yml
@@ -3,7 +3,7 @@ diag_table: gs://vcm-fv3config/config/diag_table/no_output/v1.0/diag_table
 field_table: gs://vcm-fv3config/config/field_table/baroclinic_test/v1.0/field_table
 experiment_name: c320_6ranks_baroclinic
 forcing: gs://vcm-fv3config/data/base_forcing/v1.1/
-orographic_forcing: gs://vcm-fv3config/data/orographic_data/v1.0
+orographic_forcing: ""
 # To use internal test cases, point to an empty ICs directory
 initial_conditions: ""
 namelist:


### PR DESCRIPTION
Since a more recent version, fv3config now supports passing emply list's for orography, which is not required for running a baroclinic testcase.