### PR TITLE
also generate an input.yml file

### DIFF
--- a/tests/serialized_test_data_generation/Makefile
+++ b/tests/serialized_test_data_generation/Makefile
@@ -82,6 +82,7 @@ run_model: ## run model using Docker image to generate serialized data
 		find . -type f \( -name "*.dat" -o -name "*.nml" -o -name "*.json" \) -exec md5sum {} \; > md5sums.txt
 	./check_data_dir.sh $(DATA_DIR_HOST)
 	cp $(EXPERIMENT_DIR)/$(EXPERIMENT).yml $(DATA_DIR_HOST)
+	cp $(EXPERIMENT_DIR)/$(EXPERIMENT).yml $(DATA_DIR_HOST)/input.yml
 
 pack_data: ## pack *.dat files into a *.tar.gz and delete them
 	@echo ""


### PR DESCRIPTION
Currently the makefile and jenkins plans have manual logic for setting up test directories, where an experiment yml file must be moved to input.yml before the directory can be used. This tightly couples the EXPERIMENT argument, the data path, and the remote data file structure. 
Here we  rename the yml files in the data directories to input.yml so the remote data is useful as-is.