### PR TITLE
corner conditionals should be initialized before they're consumed

### DIFF
--- a/FV3/atmos_cubed_sphere/model/fv_arrays.F90
+++ b/FV3/atmos_cubed_sphere/model/fv_arrays.F90
@@ -232,7 +232,7 @@ module fv_arrays_mod
 
      real(kind=R_GRID) :: global_area
      logical :: g_sum_initialized = .false. !< Not currently used but can be useful
-     logical:: w_corner = .false., se_corner = .false., ne_corner = .false., nw_corner = .false.
+     logical:: sw_corner, se_corner, ne_corner, nw_corner
 
      real(kind=R_GRID) :: da_min, da_max, da_min_c, da_max_c
 

--- a/FV3/atmos_cubed_sphere/model/fv_arrays.F90
+++ b/FV3/atmos_cubed_sphere/model/fv_arrays.F90
@@ -232,7 +232,7 @@ module fv_arrays_mod
 
      real(kind=R_GRID) :: global_area
      logical :: g_sum_initialized = .false. !< Not currently used but can be useful
-     logical:: sw_corner, se_corner, ne_corner, nw_corner
+     logical:: w_corner = .false., se_corner = .false., ne_corner = .false., nw_corner = .false.
 
      real(kind=R_GRID) :: da_min, da_max, da_min_c, da_max_c
 

--- a/FV3/atmos_cubed_sphere/model/fv_arrays.F90
+++ b/FV3/atmos_cubed_sphere/model/fv_arrays.F90
@@ -232,7 +232,7 @@ module fv_arrays_mod
 
      real(kind=R_GRID) :: global_area
      logical :: g_sum_initialized = .false. !< Not currently used but can be useful
-     logical:: sw_corner, se_corner, ne_corner, nw_corner
+     logical:: sw_corner = .false., se_corner = .false., ne_corner = .false., nw_corner = .false.
 
      real(kind=R_GRID) :: da_min, da_max, da_min_c, da_max_c
 

--- a/FV3/atmos_cubed_sphere/tools/fv_grid_tools.F90
+++ b/FV3/atmos_cubed_sphere/tools/fv_grid_tools.F90
@@ -659,6 +659,11 @@ contains
     latlon = .false.
     cubed_sphere = .false.
 
+    sw_corner = .false.
+    se_corner = .false.
+    ne_corner = .false.
+    nw_corner = .false.
+
     if ( Atm%flagstruct%do_schmidt .and. abs(atm%flagstruct%stretch_fac-1.) > 1.E-5 ) stretched_grid = .true.
 
     if (Atm%flagstruct%grid_type>3) then

--- a/FV3/atmos_cubed_sphere/tools/fv_grid_tools.F90
+++ b/FV3/atmos_cubed_sphere/tools/fv_grid_tools.F90
@@ -659,11 +659,6 @@ contains
     latlon = .false.
     cubed_sphere = .false.
 
-    sw_corner = .false.
-    se_corner = .false.
-    ne_corner = .false.
-    nw_corner = .false.
-
     if ( Atm%flagstruct%do_schmidt .and. abs(atm%flagstruct%stretch_fac-1.) > 1.E-5 ) stretched_grid = .true.
 
     if (Atm%flagstruct%grid_type>3) then


### PR DESCRIPTION
The `init_grid` subroutine has conditionals to determine whether a tile corner is present, and then does specific calculations for the c-grid area at those corners. Currently those conditionals are never set, but are consumed. To ensure consistency (and to bring the code in-line with the NOAA code) these should be set to `.false.` at the start of `fv_arrays`.

Code Changes:
- `fv_arrays.F90`: set sw_corner se_corner, ne_corner, and nw_corner to false in the grid type allocations